### PR TITLE
FIX: Metamask doesn't inject in Firefox under strict CSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "web3modal",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web3modal",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "MIT",
       "dependencies": {
+        "@metamask/post-message-stream": "^6.0.0",
+        "@metamask/providers": "^9.1.0",
         "detect-browser": "^5.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
@@ -2080,6 +2082,112 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@metamask/object-multiplex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+      "integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+      "dependencies": {
+        "end-of-stream": "^1.4.4",
+        "once": "^1.4.0",
+        "readable-stream": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@metamask/post-message-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/post-message-stream/-/post-message-stream-6.0.0.tgz",
+      "integrity": "sha512-z0l6UMW3z6W4qIhKSh48/6n2Q9AG1oOh9tus+Ncs9w6dAbkElKke+mXZ7tT6oAyE3T4JZLnDfGKbPWYoq+nrsA==",
+      "dependencies": {
+        "@metamask/utils": "^2.0.0",
+        "readable-stream": "2.3.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@metamask/post-message-stream/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw=="
+    },
+    "node_modules/@metamask/post-message-stream/node_modules/readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@metamask/post-message-stream/node_modules/string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@metamask/providers": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-9.1.0.tgz",
+      "integrity": "sha512-ZMfdIZ8PzaK1m0NblQOPTuDaMuTStSxrUYJiDNRi+UDqVd84WItQVXe3jy0k7TzhpjkbzgXrTK7rUcoQRhkwtw==",
+      "dependencies": {
+        "@metamask/object-multiplex": "^1.1.0",
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "@types/chrome": "^0.0.136",
+        "detect-browser": "^5.2.0",
+        "eth-rpc-errors": "^4.0.2",
+        "extension-port-stream": "^2.0.1",
+        "fast-deep-equal": "^2.0.1",
+        "is-stream": "^2.0.0",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^3.0.0",
+        "pump": "^3.0.0",
+        "webextension-polyfill-ts": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@metamask/providers/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+    },
+    "node_modules/@metamask/providers/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+    },
+    "node_modules/@metamask/utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-4PHdo5B1ifpw6GbsdlDpp8oqA++rddSmt2pWBHtIGGL2tQMvmfHdaDDSns4JP9iC+AbMogVcUpv5Vt8ow1zsRA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "dev": true,
@@ -2112,6 +2220,33 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.136",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+      "integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ=="
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -3793,7 +3928,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -4221,7 +4355,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4717,6 +4850,14 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
+    "node_modules/eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.0.10",
       "dev": true,
@@ -5139,6 +5280,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extension-port-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+      "integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+      "dependencies": {
+        "webextension-polyfill-ts": "^0.22.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extension-port-stream/node_modules/webextension-polyfill-ts": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+      "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+      "deprecated": "This project has moved to @types/webextension-polyfill",
+      "dependencies": {
+        "webextension-polyfill": "^0.7.0"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "dev": true,
@@ -5197,7 +5358,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5209,6 +5369,11 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
@@ -6184,7 +6349,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6609,7 +6773,6 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6701,6 +6864,27 @@
       "version": "2.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/json-rpc-middleware-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+      "integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
+      }
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -7830,7 +8014,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8189,7 +8372,6 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -8255,7 +8437,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -8440,7 +8621,6 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -8811,7 +8991,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
@@ -9599,7 +9778,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10651,7 +10829,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -11298,6 +11475,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+    },
+    "node_modules/webextension-polyfill-ts": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+      "integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+      "deprecated": "This project has moved to @types/webextension-polyfill",
+      "dependencies": {
+        "webextension-polyfill": "^0.7.0"
+      }
+    },
     "node_modules/webpack": {
       "version": "4.46.0",
       "dev": true,
@@ -11668,7 +11859,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -13011,6 +13201,98 @@
       "version": "1.2.1",
       "dev": true
     },
+    "@metamask/object-multiplex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+      "integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+      "requires": {
+        "end-of-stream": "^1.4.4",
+        "once": "^1.4.0",
+        "readable-stream": "^2.3.3"
+      }
+    },
+    "@metamask/post-message-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/post-message-stream/-/post-message-stream-6.0.0.tgz",
+      "integrity": "sha512-z0l6UMW3z6W4qIhKSh48/6n2Q9AG1oOh9tus+Ncs9w6dAbkElKke+mXZ7tT6oAyE3T4JZLnDfGKbPWYoq+nrsA==",
+      "requires": {
+        "@metamask/utils": "^2.0.0",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw=="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "@metamask/providers": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-9.1.0.tgz",
+      "integrity": "sha512-ZMfdIZ8PzaK1m0NblQOPTuDaMuTStSxrUYJiDNRi+UDqVd84WItQVXe3jy0k7TzhpjkbzgXrTK7rUcoQRhkwtw==",
+      "requires": {
+        "@metamask/object-multiplex": "^1.1.0",
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "@types/chrome": "^0.0.136",
+        "detect-browser": "^5.2.0",
+        "eth-rpc-errors": "^4.0.2",
+        "extension-port-stream": "^2.0.1",
+        "fast-deep-equal": "^2.0.1",
+        "is-stream": "^2.0.0",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^3.0.0",
+        "pump": "^3.0.0",
+        "webextension-polyfill-ts": "^0.25.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        }
+      }
+    },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+    },
+    "@metamask/utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-4PHdo5B1ifpw6GbsdlDpp8oqA++rddSmt2pWBHtIGGL2tQMvmfHdaDDSns4JP9iC+AbMogVcUpv5Vt8ow1zsRA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "dev": true,
@@ -13033,6 +13315,33 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/chrome": {
+      "version": "0.0.136",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+      "integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+    },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -14228,8 +14537,7 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "cors": {
       "version": "2.8.5",
@@ -14532,7 +14840,6 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -14864,6 +15171,14 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
+    "eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "ethereum-bloom-filters": {
       "version": "1.0.10",
       "dev": true,
@@ -15176,6 +15491,24 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "extension-port-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+      "integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+      "requires": {
+        "webextension-polyfill-ts": "^0.22.0"
+      },
+      "dependencies": {
+        "webextension-polyfill-ts": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+          "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+          "requires": {
+            "webextension-polyfill": "^0.7.0"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "dev": true,
@@ -15215,8 +15548,7 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -15225,6 +15557,11 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -15862,8 +16199,7 @@
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "dev": true
+      "version": "2.0.4"
     },
     "ini": {
       "version": "1.3.8",
@@ -16103,8 +16439,7 @@
       "dev": true
     },
     "isarray": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "isexe": {
       "version": "2.0.0",
@@ -16167,6 +16502,24 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true
+    },
+    "json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      }
+    },
+    "json-rpc-middleware-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+      "integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
+      }
     },
     "json-schema": {
       "version": "0.4.0",
@@ -16992,7 +17345,6 @@
     },
     "once": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -17212,8 +17564,7 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "progress": {
       "version": "2.0.3",
@@ -17266,7 +17617,6 @@
     },
     "pump": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -17399,7 +17749,6 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -17656,8 +18005,7 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "dev": true
+      "version": "5.1.2"
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -18220,7 +18568,6 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -18919,8 +19266,7 @@
       }
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -19394,6 +19740,19 @@
         "utf8": "3.0.0"
       }
     },
+    "webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+    },
+    "webextension-polyfill-ts": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+      "integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+      "requires": {
+        "webextension-polyfill": "^0.7.0"
+      }
+    },
     "webpack": {
       "version": "4.46.0",
       "dev": true,
@@ -19643,8 +20002,7 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "ws": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
   },
   "dependencies": {
     "detect-browser": "^5.1.0",
+    "@metamask/post-message-stream": "^6.0.0",
+    "@metamask/providers": "^9.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
Fixing a known issue with Metamask in Firefox under strict Content-Security-Policy that prevents from injecting the provider js object. 

See https://github.com/MetaMask/metamask-extension/issues/3133