### PR TITLE
docs(readme): adds development instructions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,52 @@
+# Development
+
+## Workspace setup
+
+Install dependencies from the repository's root directory (this will also set up each workspace):
+
+```bash
+yarn
+```
+
+Common commands:
+
+- `yarn dev` - Build and watch all packages for changes simultaneously.
+- `yarn build` - Build all packages + examples.
+- `yarn lint` - Run the linter.
+- `yarn prettier` - Run prettier.
+
+## React Example
+
+### Configuration
+
+Create your own `.env.local` file and add your ProjectID from [cloud.walletconnect.com](https://cloud.walletconnect.com/):
+
+```bash
+# 1. change into example directory
+cd ./examples/react
+# 2. Copy the template env file
+cp .env.local.example .env.local
+# 3. Replace the NEXT_PUBLIC_PROJECT_ID placeholder inside `.env.local` with your own projectId
+```
+
+Run the app:
+
+```bash
+yarn dev
+```
+
+### Reflecting local package changes
+
+Via symlinking:
+
+```bash
+# 1. Set up the package for symlinking
+cd packages/core
+yarn link
+
+# 2. Symlink the demo to our local copy of the package.
+cd examples/react
+yarn link "@web3modal/core"
+
+# 3. Changes made to `packages/core` should now reflect in the app.
+```

--- a/examples/react/.env.local.example
+++ b/examples/react/.env.local.example
@@ -1,0 +1,2 @@
+# Get your projectId at https://cloud.walletconnect.com
+NEXT_PUBLIC_PROJECT_ID=YOUR_PROJECT_ID

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "npm run build --ws --if-present",
     "dev": "npm run dev --w=@web3modal/core & npm run dev --w=@web3modal/ui & npm run dev --w=@web3modal/ethereum",
-    "dev:html": "npm run dev --w=html-example",
     "dev:react": "npm run dev --w=react-example",
     "lint": "eslint .",
     "prettier": "prettier --check .",

--- a/readme.md
+++ b/readme.md
@@ -43,55 +43,6 @@ Web3Modal exposes some config options that allow you to personalise it and make 
 | theme       | `dark`, `light`                                                       |
 | accentColor | `blackWhite`, `blue`, `default`, `green`, `magenta`, `orange`, `teal` |
 
-## Development
+## Contributing
 
-### Workspace setup
-
-Install dependencies from the repository's root directory (this will also set up each workspace):
-
-```bash
-yarn
-```
-
-Common commands:
-
-- `yarn dev` - Build and watch all packages for changes simultaneously.
-- `yarn build` - Build all packages + examples.
-- `yarn lint` - Run the linter.
-- `yarn prettier` - Run prettier.
-
-### React Example
-
-#### Configuration
-
-Create your own `.env.local` file and add your ProjectID from [cloud.walletconnect.com](https://cloud.walletconnect.com/):
-
-```bash
-# 1. change into example directory
-cd ./examples/react
-# 2. Copy the template env file
-cp .env.local.example .env.local
-# 3. Replace the NEXT_PUBLIC_PROJECT_ID placeholder inside `.env.local` with your own projectId
-```
-
-Run the app:
-
-```bash
-yarn dev
-```
-
-#### Reflecting local package changes
-
-Via symlinking:
-
-```bash
-# 1. Set up the package for symlinking
-cd packages/core
-yarn link
-
-# 2. Symlink the demo to our local copy of the package.
-cd examples/react
-yarn link "@web3modal/core"
-
-# 3. Changes made to `packages/core` should now reflect in the app.
-```
+If you want to contribute to the development of Web3Modal, please follow the instructions in [Development](docs/development.md).

--- a/readme.md
+++ b/readme.md
@@ -42,3 +42,56 @@ Web3Modal exposes some config options that allow you to personalise it and make 
 | ----------- | --------------------------------------------------------------------- |
 | theme       | `dark`, `light`                                                       |
 | accentColor | `blackWhite`, `blue`, `default`, `green`, `magenta`, `orange`, `teal` |
+
+## Development
+
+### Workspace setup
+
+Install dependencies from the repository's root directory (this will also set up each workspace):
+
+```bash
+yarn
+```
+
+Common commands:
+
+- `yarn dev` - Build and watch all packages for changes simultaneously.
+- `yarn build` - Build all packages + examples.
+- `yarn lint` - Run the linter.
+- `yarn prettier` - Run prettier.
+
+### React Example
+
+#### Configuration
+
+Create your own `.env.local` file and add your ProjectID from [cloud.walletconnect.com](https://cloud.walletconnect.com/):
+
+```bash
+# 1. change into example directory
+cd ./examples/react
+# 2. Copy the template env file
+cp .env.local.example .env.local
+# 3. Replace the NEXT_PUBLIC_PROJECT_ID placeholder inside `.env.local` with your own projectId
+```
+
+Run the app:
+
+```bash
+yarn dev
+```
+
+#### Reflecting local package changes
+
+Via symlinking:
+
+```bash
+# 1. Set up the package for symlinking
+cd packages/core
+yarn link
+
+# 2. Symlink the demo to our local copy of the package.
+cd examples/react
+yarn link "@web3modal/core"
+
+# 3. Changes made to `packages/core` should now reflect in the app.
+```


### PR DESCRIPTION
Adding some dev setup instructions while I'm seeing it with fresh eyes.

Also:
- removes seemingly dead `dev:html` script