### PR TITLE
fix: add Exodus wallet icon

### DIFF
--- a/packages/ui/src/utils/UiHelpers.ts
+++ b/packages/ui/src/utils/UiHelpers.ts
@@ -33,7 +33,8 @@ export function getWalletIcon(name: string) {
     'Brave Wallet': '125e828e-9936-4451-a8f2-949c119b7400',
     MetaMask: '619537c0-2ff3-4c78-9ed8-a05e7567f300',
     'Coinbase Wallet': 'f8068a7f-83d7-4190-1f94-78154a12c600',
-    'Ledger Live': '39890ad8-5b2e-4df6-5db4-2ff5cf4bb300'
+    'Ledger Live': '39890ad8-5b2e-4df6-5db4-2ff5cf4bb300',
+    'Exodus': '4c16cad4-cac9-4643-6726-c696efaf5200',
   }
 
   return `${cdn}/${presets[name] ?? fallback}?projectId=${projectId}`


### PR DESCRIPTION
###
The default icon is shown when Exodus wallet is displayed. This PR adds Exodus wallet icon Id to the preset icon list to fetch Exodus actual icon 


<img width="416" alt="image" src="https://user-images.githubusercontent.com/38049232/194957405-fcc5d449-70f1-4a45-b8de-402d1ee24908.png">
