### PR TITLE
[fix] react example in dev mode

### DIFF
--- a/examples/react/next.config.js
+++ b/examples/react/next.config.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+
+/**
+ * NOTE: This config is only required within this monorepo.
+ * Nextjs does not transpile web3modal packages imported from monorepo and throws an error.
+ */
+
+const nextTranspileModules = require('next-transpile-modules')
+
+const withTranspileModules = nextTranspileModules(['@web3modal/react', '@web3modal/ethereum'])
+
+const nextConfig = withTranspileModules({})
+
+module.exports = nextConfig

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/node": "18.11.4",
     "@types/react": "18.0.21",
-    "@types/react-dom": "18.0.6"
+    "@types/react-dom": "18.0.6",
+    "next-transpile-modules": "9.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,6 +3504,14 @@ end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -4663,7 +4671,7 @@ globby@^11.0.2, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -5976,6 +5984,14 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+next-transpile-modules@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.1.0.tgz#dffd2563bf76f8afdb28f0611948f46252ca65ef"
+  integrity sha512-yzJji65xDqcIqjvx5vPJcs1M+MYQTzLM1pXH/qf8Q88ohx+bwVGDc1AeV+HKr1NwvMCNTpwVPSFI7cA5WdyeWA==
+  dependencies:
+    enhanced-resolve "^5.10.0"
+    escalade "^3.1.1"
 
 next@12.3.1:
   version "12.3.1"
@@ -7582,6 +7598,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 tar-stream@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
There was some caching done within `.next` folder of react example that made following error slip by:

When repository is pulled fresh and users try to run react example, they encounter an error like this
```
error - ../../chains/ethereum/index.ts
Module parse failed: Unexpected token (1:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> export type { Chain, ChainProviderFn, Connector, Provider, WebSocketProvider } from '@wagmi/core'
| export { Web3ModalEthereum } from './src/api'
| export { chains, providers } from './src/utils/wagmiTools'
``` 

After some investigation, it looks like it was happening because nextjs in `dev` mode does not transpile linked monorepo packages (not an issue during build as all of them are pre-built or when these are used from npm). Sollution is to use [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)

closes https://github.com/WalletConnect/web3modal/issues/628