### PR TITLE
Fix: Updated React Examples

### DIFF
--- a/examples/react/src/data/goerliUSDC.json
+++ b/examples/react/src/data/goerliUSDC.json
@@ -1,0 +1,63 @@
+[
+  {
+    "inputs": [{ "internalType": "address", "name": "implementationContract", "type": "address" }],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "previousAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "implementation", "type": "address" }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  { "stateMutability": "payable", "type": "fallback" },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newAdmin", "type": "address" }],
+    "name": "changeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newImplementation", "type": "address" }],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newImplementation", "type": "address" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/examples/react/src/pages/_app.tsx
+++ b/examples/react/src/pages/_app.tsx
@@ -22,7 +22,9 @@ const modalConfig = {
       chains.binanceSmartChain,
       chains.fantom,
       chains.arbitrum,
-      chains.optimism
+      chains.optimism,
+      chains.goerli,
+      chains.polygonMumbai
     ],
     providers: [providers.walletConnectProvider({ projectId: process.env.NEXT_PUBLIC_PROJECT_ID })]
   }

--- a/examples/react/src/pages/index.tsx
+++ b/examples/react/src/pages/index.tsx
@@ -1,26 +1,10 @@
 import { useAccount, useConnectModal, Web3Button } from '@web3modal/react'
 import UseAccount from '../sections/UseAccount'
-import UseBalance from '../sections/UseBalance'
-import UseBlockNumber from '../sections/UseBlockNumber'
 import UseContract from '../sections/UseContract'
 import UseContractEvent from '../sections/UseContractEvent'
 import UseContractRead from '../sections/UseContractRead'
 import UseContractWrite from '../sections/UseContractWrite'
 import UseDisconnect from '../sections/UseDisconnect'
-import UseEnsAddress from '../sections/UseEnsAddress'
-import UseEnsAvatar from '../sections/UseEnsAvatar'
-import UseEnsName from '../sections/UseEnsName'
-import UseEnsResolver from '../sections/UseEnsResolver'
-import UseFeeData from '../sections/UseFeeData'
-import UseNetwork from '../sections/UseNetwork'
-import UseProvider from '../sections/UseProvider'
-import UsePrepareSendWaitTransaction from '../sections/UseSendTransaction'
-import UseSigner from '../sections/UseSigner'
-import UseSignMessage from '../sections/UseSignMessage'
-import UseSignTypedData from '../sections/UseSignTypedData'
-import UseSwitchNetwork from '../sections/UseSwitchNetwork'
-import UseToken from '../sections/UseToken'
-import UseTransaction from '../sections/UseTransaction'
 
 export default function HomePage() {
   const { account } = useAccount()
@@ -35,9 +19,9 @@ export default function HomePage() {
         <>
           <UseAccount />
           <UseDisconnect />
-          <UseNetwork />
-          <UseSwitchNetwork />
-          <UseBlockNumber />
+          {/* <UseNetwork />
+          <UseSwitchNetwork /> */}
+          {/* <UseBlockNumber />
           <UseFeeData />
           <UseBalance />
           <UseProvider />
@@ -50,7 +34,7 @@ export default function HomePage() {
           <UseEnsResolver />
           <UseToken />
           <UseTransaction />
-          <UsePrepareSendWaitTransaction />
+          <UsePrepareSendWaitTransaction /> */}
           <UseContract />
           <UseContractRead />
           <UseContractWrite />

--- a/examples/react/src/pages/index.tsx
+++ b/examples/react/src/pages/index.tsx
@@ -1,10 +1,26 @@
 import { useAccount, useConnectModal, Web3Button } from '@web3modal/react'
 import UseAccount from '../sections/UseAccount'
+import UseBalance from '../sections/UseBalance'
+import UseBlockNumber from '../sections/UseBlockNumber'
 import UseContract from '../sections/UseContract'
 import UseContractEvent from '../sections/UseContractEvent'
 import UseContractRead from '../sections/UseContractRead'
 import UseContractWrite from '../sections/UseContractWrite'
 import UseDisconnect from '../sections/UseDisconnect'
+import UseEnsAddress from '../sections/UseEnsAddress'
+import UseEnsAvatar from '../sections/UseEnsAvatar'
+import UseEnsName from '../sections/UseEnsName'
+import UseEnsResolver from '../sections/UseEnsResolver'
+import UseFeeData from '../sections/UseFeeData'
+import UseNetwork from '../sections/UseNetwork'
+import UseProvider from '../sections/UseProvider'
+import UsePrepareSendWaitTransaction from '../sections/UseSendTransaction'
+import UseSigner from '../sections/UseSigner'
+import UseSignMessage from '../sections/UseSignMessage'
+import UseSignTypedData from '../sections/UseSignTypedData'
+import UseSwitchNetwork from '../sections/UseSwitchNetwork'
+import UseToken from '../sections/UseToken'
+import UseTransaction from '../sections/UseTransaction'
 
 export default function HomePage() {
   const { account } = useAccount()
@@ -19,9 +35,9 @@ export default function HomePage() {
         <>
           <UseAccount />
           <UseDisconnect />
-          {/* <UseNetwork />
-          <UseSwitchNetwork /> */}
-          {/* <UseBlockNumber />
+          <UseNetwork />
+          <UseSwitchNetwork />
+          <UseBlockNumber />
           <UseFeeData />
           <UseBalance />
           <UseProvider />
@@ -34,7 +50,7 @@ export default function HomePage() {
           <UseEnsResolver />
           <UseToken />
           <UseTransaction />
-          <UsePrepareSendWaitTransaction /> */}
+          <UsePrepareSendWaitTransaction />
           <UseContract />
           <UseContractRead />
           <UseContractWrite />

--- a/examples/react/src/sections/UseContract.tsx
+++ b/examples/react/src/sections/UseContract.tsx
@@ -1,5 +1,5 @@
-import { useContract, useNetwork, useProvider, useSigner } from '@web3modal/react'
-import { useEffect, useState } from 'react'
+import { useContract, useNetwork, useProvider } from '@web3modal/react'
+import { useState } from 'react'
 import goerliUSDC from '../data/goerliUSDC.json'
 import wagmigotchiAbi from '../data/wagmigotchiAbi.json'
 
@@ -7,51 +7,37 @@ export default function UseContract() {
   const { network } = useNetwork()
   const chainId = network?.chain?.id
   const { provider } = useProvider({ chainId })
-  const { data: signer, isLoading } = useSigner()
+  // Const { data: signer, isLoading } = useSigner()
 
-  const [hungerData, setHungerData] = useState()
+  const [hungerData, setHungerData] = useState(null)
 
+  // WagmiGothchi Contract (Mainnet) / Goerli USDC Contract (Goerli)
   const goerliHref =
     'https://goerli.etherscan.io/address/0x07865c6e87b9f70255377e024ace6630c1eaa37f#code'
   const mainnetHref = 'https://etherscan.io/address/0xeCB504D39723b0be0e3a9Aa33D646642D1051EE1#code'
 
-  // WagmiGothchi Contract (Mainnet)
   const ethAddress = '0xeCB504D39723b0be0e3a9Aa33D646642D1051EE1'
-  // Goerli USDC Contract (Ethereum)
   const goerliAddress = '0x07865c6e87b9f70255377e024ace6630c1eaa37f'
 
-  // 📄 Contract Config
-  const contractReadConfig = {
-    address: chainId === 1 ? ethAddress : goerliAddress,
-    abi: chainId === 1 ? wagmigotchiAbi : goerliUSDC
-  }
-
+  // eslint-disable-next-line no-warning-comments
+  // ToDo: Debug why signer is not passing properly in signerOrProvider
   const contractConfig = {
-    ...contractReadConfig,
-    signerOrProvider: signer ? signer : provider
+    address: chainId === 1 ? ethAddress : goerliAddress,
+    abi: chainId === 1 ? wagmigotchiAbi : goerliUSDC,
+    signerOrProvider: provider
   }
 
   const { contract } = useContract(contractConfig)
 
-  // eslint-disable-next-line func-style
   async function getHunger() {
     if (contract) {
       const data = await contract.getHunger()
-      setHungerData(JSON.stringify(data))
+      setHungerData(data)
     }
   }
 
-  useEffect(() => {
-    // If (contract) getHunger()
-  }, [hungerData, isLoading, provider, signer])
-
-  async function feed() {
-    if (contract) {
-      const tx = await contract.feed()
-      const response = await tx.wait()
-    }
-  }
-
+  // eslint-disable-next-line no-warning-comments
+  // ToDo: Add the contract action calls for Goerli USDC Contract
   return (
     <section>
       <h1>useContract</h1>
@@ -67,15 +53,12 @@ export default function UseContract() {
         <li>
           Contract Address: <span>{contract?.address}</span>
         </li>
-        <li>Hunger Data / getHunger call function: {hungerData}</li>
-        <li>Feed/ write function:</li>
+        <li>Hunger Data / getHunger call function: {JSON.stringify(hungerData)}</li>
       </ul>
       <div style={{ display: 'flex' }}>
         <button style={{ marginRight: '1rem' }} onClick={async () => getHunger()}>
           Get Hunger
         </button>
-        {/* <button onClick={async () => feed()}>Feed</button> */}
-        <button>Feed</button>
       </div>
     </section>
   )

--- a/examples/react/src/sections/UseContract.tsx
+++ b/examples/react/src/sections/UseContract.tsx
@@ -1,33 +1,82 @@
-import { useContract } from '@web3modal/react'
+import { useContract, useNetwork, useProvider, useSigner } from '@web3modal/react'
+import { useEffect, useState } from 'react'
+import goerliUSDC from '../data/goerliUSDC.json'
 import wagmigotchiAbi from '../data/wagmigotchiAbi.json'
 
 export default function UseContract() {
-  const { contract } = useContract({
-    address: '0xeCB504D39723b0be0e3a9Aa33D646642D1051EE1',
-    abi: wagmigotchiAbi
-  })
+  const { network } = useNetwork()
+  const chainId = network?.chain?.id
+  const { provider } = useProvider({ chainId })
+  const { data: signer, isLoading } = useSigner()
+
+  const [hungerData, setHungerData] = useState()
+
+  const goerliHref =
+    'https://goerli.etherscan.io/address/0x07865c6e87b9f70255377e024ace6630c1eaa37f#code'
+  const mainnetHref = 'https://etherscan.io/address/0xeCB504D39723b0be0e3a9Aa33D646642D1051EE1#code'
+
+  // WagmiGothchi Contract (Mainnet)
+  const ethAddress = '0xeCB504D39723b0be0e3a9Aa33D646642D1051EE1'
+  // Goerli USDC Contract (Ethereum)
+  const goerliAddress = '0x07865c6e87b9f70255377e024ace6630c1eaa37f'
+
+  // 📄 Contract Config
+  const contractReadConfig = {
+    address: chainId === 1 ? ethAddress : goerliAddress,
+    abi: chainId === 1 ? wagmigotchiAbi : goerliUSDC
+  }
+
+  const contractConfig = {
+    ...contractReadConfig,
+    signerOrProvider: signer ? signer : provider
+  }
+
+  const { contract } = useContract(contractConfig)
+
+  // eslint-disable-next-line func-style
+  async function getHunger() {
+    if (contract) {
+      const data = await contract.getHunger()
+      setHungerData(JSON.stringify(data))
+    }
+  }
+
+  useEffect(() => {
+    // If (contract) getHunger()
+  }, [hungerData, isLoading, provider, signer])
+
+  async function feed() {
+    if (contract) {
+      const tx = await contract.feed()
+      const response = await tx.wait()
+    }
+  }
 
   return (
     <section>
       <h1>useContract</h1>
-
       <p>
         This example uses
-        <a
-          href="https://etherscan.io/address/0xecb504d39723b0be0e3a9aa33d646642d1051ee1#code"
-          target="_blank"
-          rel="noopener noreferer"
-        >
-          WagmiGotchi Contract
+        <a href={chainId === 1 ? mainnetHref : goerliHref} target="_blank" rel="noopener noreferer">
+          {chainId === 1 ? 'WagmiGotchi Contract' : 'USDC Contract'}
         </a>
-        on Ethereum
+        on {network?.chain?.name}
       </p>
 
       <ul>
         <li>
           Contract Address: <span>{contract?.address}</span>
         </li>
+        <li>Hunger Data / getHunger call function: {hungerData}</li>
+        <li>Feed/ write function:</li>
       </ul>
+      <div style={{ display: 'flex' }}>
+        <button style={{ marginRight: '1rem' }} onClick={async () => getHunger()}>
+          Get Hunger
+        </button>
+        {/* <button onClick={async () => feed()}>Feed</button> */}
+        <button>Feed</button>
+      </div>
     </section>
   )
 }

--- a/examples/react/src/sections/UseContract.tsx
+++ b/examples/react/src/sections/UseContract.tsx
@@ -9,7 +9,7 @@ export default function UseContract() {
   const { provider } = useProvider({ chainId })
   // Const { data: signer, isLoading } = useSigner()
 
-  const [hungerData, setHungerData] = useState(null)
+  const [hungerData, setHungerData] = useState()
 
   // WagmiGothchi Contract (Mainnet) / Goerli USDC Contract (Goerli)
   const goerliHref =

--- a/examples/react/src/sections/UseContractRead.tsx
+++ b/examples/react/src/sections/UseContractRead.tsx
@@ -1,4 +1,3 @@
-import { chains } from '@web3modal/ethereum'
 import { useContractRead } from '@web3modal/react'
 import wagmigotchiAbi from '../data/wagmigotchiAbi.json'
 
@@ -7,7 +6,7 @@ export default function UseContractRead() {
     address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     abi: wagmigotchiAbi,
     functionName: 'getHunger',
-    chainId: chains.mainnet.id
+    chainId: 'any'
   }
   const { data, error, isLoading, refetch } = useContractRead(config)
 

--- a/examples/react/src/sections/UseContractRead.tsx
+++ b/examples/react/src/sections/UseContractRead.tsx
@@ -8,6 +8,8 @@ export default function UseContractRead() {
     functionName: 'getHunger',
     chainId: 'any'
   }
+
+  // @ts-expect-error - If being chain agnostic, chainId is not required
   const { data, error, isLoading, refetch } = useContractRead(config)
 
   return (

--- a/examples/react/src/sections/UseContractWrite.tsx
+++ b/examples/react/src/sections/UseContractWrite.tsx
@@ -1,13 +1,14 @@
-import { chains } from '@web3modal/ethereum'
-import { useContractWrite, useWaitForTransaction } from '@web3modal/react'
+import { useContractWrite, useNetwork, useWaitForTransaction } from '@web3modal/react'
 import wagmigotchiABI from '../data/wagmigotchiAbi.json'
 
 export default function UseContractWrite() {
+  const { network } = useNetwork()
+
   const config = {
     address: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     abi: wagmigotchiABI,
     functionName: 'feed',
-    chainId: chains.mainnet.id
+    chainId: network?.chain?.id
   }
 
   const { data, error, isLoading, write } = useContractWrite(config)

--- a/examples/react/src/sections/UseToken.tsx
+++ b/examples/react/src/sections/UseToken.tsx
@@ -1,12 +1,16 @@
-import { useToken } from '@web3modal/react'
+import { useNetwork, useToken } from '@web3modal/react'
 
 export default function UseToken() {
   const address = '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72'
-  const { data, isLoading, error, refetch } = useToken({ address })
+  const { data, isLoading, error, refetch } = useToken({ address, chainId: 1 })
+  const { network } = useNetwork()
 
   return (
     <section>
       <h1>useToken</h1>
+      <p>
+        {network && network.chain?.id !== 1 ? 'This ENS Token is only on Ethereum Mainnet' : null}
+      </p>
       <ul>
         <li>
           Address $ENS: <span>{address}</span>


### PR DESCRIPTION
### Overview
- Explores #669 
- This seems to behave as per our library if configured correctly.

### Tested & Works
- Have tested the userflow of network switching of networks (ETH + Goerli) + reading + writing to different contracts with `useContractWrite` and `useContractRead`
- Making calls using `useContract` with `signerOrProvider: provider` / nothing passes makes the calls for data.

The recommended approach is:
1. import the correct `chains` in your modalConfig with` import { chains, providers } from '@web3modal/ethereum'`
2. Wait for users to Connect before calling hooks such as `useSigner` or `useProvider`.
3. Make sure you pass your `chainId` if you are using `useProvider` 
```
  const { network } = useNetwork()
  const chainId = network?.chain?.id
  const { provider } = useProvider({ chainId })
```
4. `useContractRead` and `useContractWrite` as opposed to `useContract`.

### To Try
1. On the interactive example / CloudFlare link below, Connect Wallet on Mainnet
2. Check `useContract` section + call the getHunger endpoint. Data should populate
3. Switch networks to Goerli in `Network Swtich` section.
4. Check `useContract` section again and the contractAddress / contract should be for Goerli USDC. (Will populate and flag check for the functions after the below debugging is solved)

### Bug / Debugging
- However while testing this ran into another issue.
When passing in signer into `useContract`, faces an issue of JSON flattening. Similarly found in [Wagmi repo in #367 ](https://github.com/wagmi-dev/wagmi/issues/367)
<img width="480" alt="image" src="https://user-images.githubusercontent.com/45455218/201069209-46d9d69f-0162-4497-8bb4-d945fc12ed05.png">

### Other Notes
- Can remove the goerli network / mumbai testnetwork + USDC contract at end of the debugging but might be useful for developers to see the contract switch

