### PR TITLE
Fixed MaskBook connetcion in Opera browsers

### DIFF
--- a/src/providers/providers/index.ts
+++ b/src/providers/providers/index.ts
@@ -21,8 +21,6 @@ import LedgerLogo from "../logos/ledger.png";
 // @ts-ignore
 import BitskiLogo from "../logos/bitski.svg";
 // @ts-ignore
-import OperaLogo from "../logos/opera.svg";
-// @ts-ignore
 import FrameLogo from "../logos/frame.svg";
 // @ts-ignore
 import BinanceChainWalletLogo from "../logos/binancechainwallet.svg";
@@ -200,14 +198,6 @@ export const SEQUENCE: IProviderInfo = {
   logo: SequenceLogo,
   type: "web",
   check: "isSequenceWeb"
-};
-
-export const OPERA: IProviderInfo = {
-  id: "opera",
-  name: "Opera",
-  logo: OperaLogo,
-  type: "injected",
-  check: "isOpera"
 };
 
 export const WEB3AUTH: IProviderInfo = {


### PR DESCRIPTION
Hello, in previous version when we try to connect MaskBook wallet in Opera browsers also in Opera GX and Crypto, we get an error like describe in thread belowe: 
`https://github.com/WalletConnect/web3modal/issues/548`

![Nowy obraz mapy bitowej](https://user-images.githubusercontent.com/112620793/203037836-c4b50ed0-e1ff-474d-bef8-0cbe3d0b3619.jpg)


Removing provider setting for Opera in providers folder solved it and don't have any impact to app.