### PR TITLE
Support for Rainbow Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A single Web3 / Ethereum provider solution for all Wallets
 
 Web3Modal is an easy-to-use library to help developers add support for multiple providers in their apps with a simple customizable configuration.
 
-By default Web3Modal Library supports injected providers like ( **Metamask**,**Brave Wallet**, **Dapper**, **Frame**, **Gnosis Safe**, **Tally**, Web3 Browsers, etc) and **WalletConnect**. You can also easily configure the library to support **Coinbase Wallet**, **Torus**, **Portis**, **Fortmatic** and many more.
+By default Web3Modal Library supports injected providers like (**Metamask**,**Rainbow**,**Brave Wallet**, **Dapper**, **Frame**, **Gnosis Safe**, **Tally**, Web3 Browsers, etc) and **WalletConnect**. You can also easily configure the library to support **Coinbase Wallet**, **Torus**, **Portis**, **Fortmatic** and many more.
 
 ## Preview
 

--- a/src/providers/injected/index.ts
+++ b/src/providers/injected/index.ts
@@ -66,6 +66,8 @@ import GameStopLogo from "../logos/gamestopwallet.svg";
 import ZerionLogo from '../logos/zerion.svg';
 // @ts-ignore
 import PhantomLogo from "../logos/phantom.svg";
+// @ts-ignore
+import RainbowLogo from "../logos/rainbow.svg";
 
 export const FALLBACK: IProviderInfo = {
   id: "injected",
@@ -332,4 +334,12 @@ export const PHANTOM: IProviderInfo = {
   package: {
     required: ["networkType"]
   }
+};
+
+export const RAINBOW: IProviderInfo = {
+  id: "injected",
+  name: "Rainbow",
+  logo: RainbowLogo,
+  type: "injected",
+  check: "isRainbow"
 };

--- a/src/providers/logos/rainbow.svg
+++ b/src/providers/logos/rainbow.svg
@@ -1,0 +1,64 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_19)">
+<mask id="mask0_1_19" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="120" height="120">
+<circle cx="60" cy="60" r="60" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_1_19)">
+<rect width="120" height="120" fill="url(#paint0_linear_1_19)"/>
+</g>
+<path d="M26.6667 41.6667H31.6667C57.44 41.6667 78.3333 62.56 78.3333 88.3333V93.3333H88.3333C91.0948 93.3333 93.3333 91.0947 93.3333 88.3333C93.3333 54.2758 65.7242 26.6667 31.6667 26.6667C28.9052 26.6667 26.6667 28.9052 26.6667 31.6667V41.6667Z" fill="url(#paint1_radial_1_19)"/>
+<path d="M80 88.3333H93.3333C93.3333 91.0948 91.0947 93.3333 88.3333 93.3333H80V88.3333Z" fill="url(#paint2_linear_1_19)"/>
+<path d="M31.6667 26.6667L31.6667 40H26.6667L26.6667 31.6667C26.6667 28.9052 28.9052 26.6667 31.6667 26.6667Z" fill="url(#paint3_linear_1_19)"/>
+<path d="M26.6666 40H31.6666C58.3604 40 80 61.6396 80 88.3333V93.3333H65V88.3333C65 69.9238 50.0761 55 31.6666 55H26.6666V40Z" fill="url(#paint4_radial_1_19)"/>
+<path d="M66.6666 88.3333H80V93.3333H66.6666V88.3333Z" fill="url(#paint5_linear_1_19)"/>
+<path d="M26.6666 53.3333L26.6666 40L31.6666 40L31.6666 53.3333H26.6666Z" fill="url(#paint6_linear_1_19)"/>
+<path d="M26.6666 61.6667C26.6666 64.4281 28.9052 66.6667 31.6666 66.6667C43.6328 66.6667 53.3333 76.3672 53.3333 88.3333C53.3333 91.0948 55.5719 93.3333 58.3333 93.3333H66.6666V88.3333C66.6666 69.0034 50.9966 53.3333 31.6666 53.3333H26.6666V61.6667Z" fill="url(#paint7_radial_1_19)"/>
+<path d="M53.3333 88.3333H66.6666V93.3333H58.3333C55.5719 93.3333 53.3333 91.0948 53.3333 88.3333Z" fill="url(#paint8_radial_1_19)"/>
+<path d="M31.6666 66.6667C28.9052 66.6667 26.6666 64.4281 26.6666 61.6667L26.6666 53.3333L31.6666 53.3333L31.6666 66.6667Z" fill="url(#paint9_radial_1_19)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1_19" x1="60" y1="0" x2="60" y2="120" gradientUnits="userSpaceOnUse">
+<stop stop-color="#174299"/>
+<stop offset="1" stop-color="#001E59"/>
+</linearGradient>
+<radialGradient id="paint1_radial_1_19" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(31.6667 88.3333) rotate(-90) scale(61.6667)">
+<stop offset="0.770277" stop-color="#FF4000"/>
+<stop offset="1" stop-color="#8754C9"/>
+</radialGradient>
+<linearGradient id="paint2_linear_1_19" x1="79.1666" y1="90.8333" x2="93.3333" y2="90.8333" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF4000"/>
+<stop offset="1" stop-color="#8754C9"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1_19" x1="29.1667" y1="26.6667" x2="29.1667" y2="40.8333" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8754C9"/>
+<stop offset="1" stop-color="#FF4000"/>
+</linearGradient>
+<radialGradient id="paint4_radial_1_19" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(31.6666 88.3333) rotate(-90) scale(48.3333)">
+<stop offset="0.723929" stop-color="#FFF700"/>
+<stop offset="1" stop-color="#FF9901"/>
+</radialGradient>
+<linearGradient id="paint5_linear_1_19" x1="66.6666" y1="90.8333" x2="80" y2="90.8333" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFF700"/>
+<stop offset="1" stop-color="#FF9901"/>
+</linearGradient>
+<linearGradient id="paint6_linear_1_19" x1="29.1666" y1="53.3333" x2="29.1666" y2="40" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFF700"/>
+<stop offset="1" stop-color="#FF9901"/>
+</linearGradient>
+<radialGradient id="paint7_radial_1_19" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(31.6666 88.3333) rotate(-90) scale(35)">
+<stop offset="0.59513" stop-color="#00AAFF"/>
+<stop offset="1" stop-color="#01DA40"/>
+</radialGradient>
+<radialGradient id="paint8_radial_1_19" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(52.5 90.8333) scale(14.1667 37.7778)">
+<stop stop-color="#00AAFF"/>
+<stop offset="1" stop-color="#01DA40"/>
+</radialGradient>
+<radialGradient id="paint9_radial_1_19" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(29.1666 67.5) rotate(-90) scale(14.1667 268.642)">
+<stop stop-color="#00AAFF"/>
+<stop offset="1" stop-color="#01DA40"/>
+</radialGradient>
+<clipPath id="clip0_1_19">
+<rect width="120" height="120" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
# Changes
- Exported `RAINBOW` injected provider metadata type
- Added Rainbow Wallet logo in `./providers/logos/`
- Updated `README` to confirm support for Rainbow's injected provider

# Tests
With Rainbow injected:
<img width="822" alt="Screenshot 2023-01-09 at 12 02 24 PM" src="https://user-images.githubusercontent.com/4412473/211365905-7abcd44d-44fd-4e15-b5ec-fd2efe2d038d.png">


With MetaMask injected:
<img width="817" alt="Screenshot 2023-01-09 at 11 50 27 AM" src="https://user-images.githubusercontent.com/4412473/211365879-a4cf6de2-15bc-469a-b22c-4c5ea5fdb655.png">
