### PR TITLE
Support for Rainbow Wallet in V2

### DIFF
--- a/packages/ui/src/presets/EthereumPresets.ts
+++ b/packages/ui/src/presets/EthereumPresets.ts
@@ -18,6 +18,7 @@ export interface InjectedPreset {
 
 export const enum InjectedId {
   metaMask = 'metaMask',
+  rainbow = 'rainbow',
   trust = 'trust',
   phantom = 'phantom',
   brave = 'brave',
@@ -44,6 +45,12 @@ export const EthereumPresets = {
       name: 'MetaMask',
       icon: '619537c0-2ff3-4c78-9ed8-a05e7567f300',
       url: 'https://metamask.io',
+      isMobile: true
+    },
+    [InjectedId.rainbow]: {
+      name: 'Rainbow',
+      icon: '6089655c-cb7e-414b-f742-01fdc154be00',
+      url: 'https://rainbow.me/extension',
       isMobile: true
     },
     [InjectedId.trust]: {
@@ -154,6 +161,7 @@ export const EthereumPresets = {
     const { ethereum, spotEthWallet, coinbaseWalletExtension }: EvmWindow = window
 
     if (!ethereum) return InjectedId.metaMask
+    if (ethereum.isRainbow) return InjectedId.rainbow
     if (ethereum.isTrust || ethereum.isTrustWallet) return InjectedId.trust
     if (ethereum.isPhantom) return InjectedId.phantom
     if (ethereum.isBraveWallet) return InjectedId.brave


### PR DESCRIPTION
## Changes
- Added `rainbow` namespace to `InjectedId` enum
- New Rainbow provider preset in `EthereumPresets` with `isMobile` fallback configuration
- Support for `ethereum.isRainbow` provider in `getInjectedId`

## Tests
### Injected Wallet
With Rainbow installed:
![](https://user-images.githubusercontent.com/4412473/211983831-72a9165c-1835-4bc8-b3a3-1edf4f2701e9.png)

With MetaMask installed:
![](https://user-images.githubusercontent.com/4412473/211983985-0c0e4c14-6478-44e1-a308-e58964992184.png)

Without a detectable provider:
![localhost (11)](https://user-images.githubusercontent.com/4412473/211983775-c8d9f3f2-b218-4f75-9bf0-26a6c29b9705.png)

### Desktop - View All
Without Rainbow installed:
![](https://user-images.githubusercontent.com/4412473/211984203-b6d00665-47a6-4287-b5a9-2459296efcea.png) ![](https://user-images.githubusercontent.com/4412473/211983917-4664618d-4b95-4422-ad3f-9e6c935f6ac6.png)