### PR TITLE
fix Less than 6 digits remain unchanged

### DIFF
--- a/packages/ui/src/partials/w3m-balance/index.ts
+++ b/packages/ui/src/partials/w3m-balance/index.ts
@@ -42,6 +42,9 @@ export class W3mBalance extends LitElement {
     if (this.amount && this.amount.length > 6) {
       formatAmount = parseFloat(this.amount).toFixed(3)
     }
+    else if(this.amount){
+      formatAmount = parseFloat(this.amount)
+    }
 
     return html`
       <div>


### PR DESCRIPTION
If the balance is less than exactly 6 digits, w3m-balance will not show the balance correctly and `_._`

## Reproduction
Create a new wallet account, transfer 0.01 and connect with that wallet.

In the output of the Web3Modal component, the `_._` appears in the output of the Web3Modal component.

<img width="189" alt="image" src="https://user-images.githubusercontent.com/32259709/219015335-0992a392-a371-4fb1-a6fa-722d96d41522.png">

## Environment
Goerli Test net , Ethereum Main net