### PR TITLE
fix: prevent name and icon mismatch for injected wallets

### DIFF
--- a/packages/ui/src/components/w3m-wallet-button/index.ts
+++ b/packages/ui/src/components/w3m-wallet-button/index.ts
@@ -32,17 +32,27 @@ export class W3mWalletButton extends LitElement {
     return null
   }
 
+  private nameTemplate() {
+    if (this.installed) {
+      const injectedName = UiUtil.getWalletNameById(this.walletId)
+
+      return html` <w3m-text variant="xsmall-regular">${injectedName}</w3m-text> `
+    }
+
+    return html`
+      <w3m-text variant="xsmall-regular">
+        ${this.label ?? UiUtil.getWalletName(this.name, true)}
+      </w3m-text>
+    `
+  }
+
   // -- render ------------------------------------------------------- //
   protected render() {
     return html`
       <button @click=${this.onClick}>
         <div>
           <w3m-wallet-image walletId=${this.walletId} .src=${this.src}></w3m-wallet-image>
-          <w3m-text variant="xsmall-regular">
-            ${this.label ?? UiUtil.getWalletName(this.name, true)}
-          </w3m-text>
-
-          ${this.sublabelTemplate()}
+          ${this.nameTemplate()} ${this.sublabelTemplate()}
         </div>
       </button>
     `

--- a/packages/ui/src/presets/EthereumPresets.ts
+++ b/packages/ui/src/presets/EthereumPresets.ts
@@ -198,5 +198,11 @@ export const EthereumPresets = {
     const id = EthereumPresets.getInjectedId('')
 
     return EthereumPresets.injectedPreset[id]?.name ?? 'Injected'
+  },
+
+  getInjectedNameById(id: string) {
+    if (!id) return 'Injected'
+
+    return EthereumPresets.injectedPreset[id]?.name ?? 'Injected'
   }
 }

--- a/packages/ui/src/utils/UiUtil.ts
+++ b/packages/ui/src/utils/UiUtil.ts
@@ -54,6 +54,13 @@ export const UiUtil = {
     return short ? injectedName.split(' ')[0] : injectedName
   },
 
+  getWalletNameById(id: string, short = false) {
+    const injectedId = EthereumPresets.getInjectedId(id)
+    const injectedName = EthereumPresets.getInjectedNameById(injectedId)
+
+    return short ? injectedName.split(' ')[0] : injectedName
+  },
+
   getChainIcon(chainId: number | string) {
     const imageId = ChainPresets[chainId]
     const { projectId, chainImages } = ConfigCtrl.state

--- a/packages/ui/src/views/w3m-injected-connector-view/index.ts
+++ b/packages/ui/src/views/w3m-injected-connector-view/index.ts
@@ -38,8 +38,8 @@ export class W3mInjectedConnectorView extends LitElement {
 
   // -- render ------------------------------------------------------- //
   protected render() {
-    const optimisticName = UiUtil.getWalletName(this.connector.name)
     const optimisticWalletId = UiUtil.getWalletId(this.connector.id)
+    const optimisticName = UiUtil.getWalletNameById(optimisticWalletId)
     const classes = {
       'w3m-injected-wrapper': true,
       'w3m-injected-error': this.error


### PR DESCRIPTION
**Bug**
It's currently possible for an injected wallet's name to not match its icon. This is currently affecting Phantom as shown in the **before** images below. 

This PR changes how names for injected wallets are detected. Instead of detecting off of an optimistic name, it detects based on the wallet's `id`. This `id` detection is currently used for wallet icons, so no behavior there is changed.

**Before**
<img width="381" alt="mm1" src="https://user-images.githubusercontent.com/15083324/226072246-5291dd2e-45c3-48ac-a098-8d9237538638.png">
<img width="387" alt="mm2" src="https://user-images.githubusercontent.com/15083324/226072258-d397e001-54d0-4940-8c97-9cd9b37ddabd.png">

**After**
<img width="377" alt="ph1" src="https://user-images.githubusercontent.com/15083324/226072279-55ba1f6d-4a75-4861-8016-05db91cba936.png">
<img width="384" alt="ph2" src="https://user-images.githubusercontent.com/15083324/226072288-56b25b92-b602-43e6-a518-3be65615318a.png">

**Additional Notes**
I've tested with the following injected wallets to make sure there was no disruption: MetaMask, Coinbase Wallet, Trust Wallet, Phantom, Taho, Core