### PR TITLE
Remove metamask id check for injected wallets

### DIFF
--- a/packages/ui/src/partials/w3m-desktop-wallet-selection/index.ts
+++ b/packages/ui/src/partials/w3m-desktop-wallet-selection/index.ts
@@ -1,9 +1,8 @@
 import type { DesktopConnectorData } from '@web3modal/core'
 import { ConfigCtrl, ExplorerCtrl, OptionsCtrl, RouterCtrl } from '@web3modal/core'
-import { html, LitElement } from 'lit'
+import { LitElement, html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
-import { InjectedId } from '../../presets/EthereumPresets'
 import { DataFilterUtil } from '../../utils/DataFilterUtil'
 import { SvgUtil } from '../../utils/SvgUtil'
 import { ThemeUtil } from '../../utils/ThemeUtil'
@@ -37,7 +36,7 @@ export class W3mDesktopWalletSelection extends LitElement {
   private async onConnectorWallet(id: string) {
     if (!window.ethereum) {
       this.onInstallConnector()
-    } else if (id === 'injected' || id === InjectedId.metaMask) {
+    } else if (id === 'injected') {
       this.onInjectedWallet()
     } else {
       await UiUtil.handleConnectorConnection(id)

--- a/packages/ui/src/views/w3m-install-connector-view/index.ts
+++ b/packages/ui/src/views/w3m-install-connector-view/index.ts
@@ -1,5 +1,5 @@
 import { CoreUtil, RouterCtrl, ToastCtrl } from '@web3modal/core'
-import { html, LitElement } from 'lit'
+import { LitElement, html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 import { SvgUtil } from '../../utils/SvgUtil'
 import { ThemeUtil } from '../../utils/ThemeUtil'
@@ -42,7 +42,8 @@ export class W3mInstallConnectorView extends LitElement {
           <div class="w3m-install-title">
             <w3m-text variant="big-bold">Install ${name}</w3m-text>
             <w3m-text color="secondary" variant="small-thin" class="w3m-info-text">
-              To connect ${name}, install the browser extension.
+              To connect ${name}, install the browser extension. If you have the extension installed,
+              having multiple wallets may conflict with each other.
             </w3m-text>
           </div>
           <div class="w3m-install-actions">

--- a/packages/ui/src/views/w3m-install-connector-view/index.ts
+++ b/packages/ui/src/views/w3m-install-connector-view/index.ts
@@ -42,8 +42,7 @@ export class W3mInstallConnectorView extends LitElement {
           <div class="w3m-install-title">
             <w3m-text variant="big-bold">Install ${name}</w3m-text>
             <w3m-text color="secondary" variant="small-thin" class="w3m-info-text">
-              To connect ${name}, install the browser extension. If you have the extension installed,
-              having multiple wallets may conflict with each other.
+              To connect ${name}, install the browser extension.
             </w3m-text>
           </div>
           <div class="w3m-install-actions">


### PR DESCRIPTION
In order to solve https://github.com/WalletConnect/web3modal/issues/892, we tried introducing the Metamask connector by overriding the w3mConnectors in wagmi client. This does work, visually, however due to this additional check for injectedConnector, it does not work for metamask wallet. Wondering why this check was there?

Sample fix on the UI side:
```
export const wagmiClient = createClient({
  autoConnect: true,
  queryClient,
  connectors: () => {
    return uniqBy(
      (connector) => connector.name,
      [
        ...w3mConnectors({
          projectId: WALLET_CONNECT_PROJECT_ID,
          version: 1,
          chains,
        }),
        new MetaMaskConnector(), // Force override due to window.ethereum conflict with coinbase & other wallets
      ],
    );
  },
  provider,
});
```