### PR TITLE
Add Dawn Wallet

### DIFF
--- a/packages/ui/src/presets/EthereumPresets.ts
+++ b/packages/ui/src/presets/EthereumPresets.ts
@@ -126,7 +126,7 @@ export const EthereumPresets = {
     },
     [InjectedId.dawn]: {
       name: 'Dawn',
-      icon: '',
+      icon: 'dcb4a287-a6f5-4e81-cbab-2d0eb27b2f00',
       url: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
       isInjected: true
     },

--- a/packages/ui/src/presets/EthereumPresets.ts
+++ b/packages/ui/src/presets/EthereumPresets.ts
@@ -35,7 +35,8 @@ export const enum InjectedId {
   tokenary = 'tokenary',
   '1inch' = '1inch',
   kuCoinWallet = 'kuCoinWallet',
-  ledger = 'ledger'
+  ledger = 'ledger',
+  dawn = 'dawn'
 }
 
 // -- presets ------------------------------------------------------ //
@@ -123,6 +124,12 @@ export const EthereumPresets = {
       url: 'https://brave.com/wallet',
       isInjected: true
     },
+    [InjectedId.dawn]: {
+      name: 'Dawn',
+      icon: '',
+      url: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
+      isInjected: true
+    },
     [InjectedId.frame]: {
       name: 'Frame',
       icon: 'cd492418-ea85-4ef1-aeed-1c9e20b58900',
@@ -186,6 +193,7 @@ export const EthereumPresets = {
     if (ethereum.isTokenary) return InjectedId.tokenary
     if (ethereum.isOneInchIOSWallet || ethereum.isOneInchAndroidWallet) return InjectedId['1inch']
     if (ethereum.isKuCoinWallet) return InjectedId.kuCoinWallet
+    if (ethereum.isDawn) return InjectedId.dawn
     if (ethereum.isMetaMask) return InjectedId.metaMask
 
     return 'injected'


### PR DESCRIPTION
# Summary
Dawn Wallet (https://twitter.com/dawn_wallet) is an iOS mobile Ethereum Wallet. We are about to enter production later this week. This PR adds support for Dawn into the Web3Modal so our users can use dapps that make use of WalletConnect. We have also submitted the `cloud.walletconnect.com` application.