### PR TITLE
fix: manualWalletsTemplate not loading MobileWallets

### DIFF
--- a/packages/ui/src/utils/TemplateUtil.ts
+++ b/packages/ui/src/utils/TemplateUtil.ts
@@ -13,7 +13,7 @@ export const TemplateUtil = {
   },
 
   manualWalletsTemplate() {
-    const wallets = DataUtil.manualDesktopWallets()
+    const wallets = DataUtil.manualWallets()
 
     return wallets.map(
       wallet => html`


### PR DESCRIPTION
Fixes the bug where a manually added mobile wallet doesn't appear on the wallet selection screen.