### PR TITLE
fix: deeplink format error

### DIFF
--- a/packages/core/src/utils/CoreUtil.ts
+++ b/packages/core/src/utils/CoreUtil.ts
@@ -49,8 +49,12 @@ export const CoreUtil = {
     }
     this.setWalletConnectDeepLink(safeAppUrl, name)
     const encodedWcUrl = encodeURIComponent(wcUri)
+    let deepLinkUrl = safeAppUrl
+    if (safeAppUrl.endsWith('/')) {
+      deepLinkUrl = safeAppUrl.slice(0, -1)
+    }
 
-    return `${safeAppUrl}wc?uri=${encodedWcUrl}`
+    return `${deepLinkUrl}/wc?uri=${encodedWcUrl}`
   },
 
   formatUniversalUrl(appUrl: string, wcUri: string, name: string): string {


### PR DESCRIPTION
Fix the bug that when the deep link has a path like `celo://wallet`, the format string will become `celo://walletwc?uri=xxx`.