### PR TITLE
Move `@web3modal/ethereum` to dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,11 +16,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@web3modal/ethereum": "2.4.2",
     "buffer": "6.0.3",
     "valtio": "1.10.5"
-  },
-  "devDependencies": {
-    "@web3modal/ethereum": "2.4.2"
   },
   "keywords": [
     "web3",


### PR DESCRIPTION
When use `@web3modal/core` in a typescript project, it will throw `Cannot find module '@web3modal/ethereum' or its corresponding type declarations` error because install `@web3modal/core` won't install `@web3modal/ethereum` as it is a dev dependency.

# Breaking Changes

N/A

# Changes

- feat:
- fix:
- chore:

# Associated Issues

closes #...