### PR TITLE
add number type to --w3m-z-index

### DIFF
--- a/packages/core/src/types/controllerTypes.ts
+++ b/packages/core/src/types/controllerTypes.ts
@@ -201,7 +201,7 @@ export interface ClientCtrlState {
 // -- ThemeCtrl -------------------------------------------- //
 export interface ThemeCtrlState {
   themeVariables?: {
-    '--w3m-z-index'?: string
+    '--w3m-z-index'?: string | number
     '--w3m-accent-color'?: string
     '--w3m-accent-fill-color'?: string
     '--w3m-background-color'?: string


### PR DESCRIPTION
# Breaking Changes

work : add number type to --w3m-z-index


When I tried to use the web3 modal within the project, there was confusion because the number type zIndex was not specified. If the number type is added to zIndex, it seems to be more convenient to use without confusion. So I did this.

# Changes

- feat:
- fix:  add number type to --w3m-z-index
- chore:

# Associated Issues

closes #...