### PR TITLE
fix: add chainImages type WalletConnectModalConfig

### DIFF
--- a/packages/walletconnect-modal/src/client.ts
+++ b/packages/walletconnect-modal/src/client.ts
@@ -6,6 +6,7 @@ import { ConfigCtrl, ModalCtrl, OptionsCtrl, ThemeCtrl } from '@web3modal/core'
  */
 export type WalletConnectModalConfig = Pick<
   ConfigCtrlState,
+  | 'chainImages'
   | 'desktopWallets'
   | 'enableAuthMode'
   | 'enableExplorer'


### PR DESCRIPTION
# Breaking Changes


The QrModalOptions type uses Pick to get the type in WalletConnectModalConfig, but the chainImages type doesn't seem to exist in WalletConnectModalConfig.


So I modified it as below. If I misunderstood, you can close the pr.

# Changes

- feat:
- fix:add chainImages type WalletConnectModalConfig
- chore:

# Associated Issues

closes #...