### PR TITLE
fix(@web3modal/ethereum): use @wagmi/core import

### DIFF
--- a/chains/ethereum/src/utils.ts
+++ b/chains/ethereum/src/utils.ts
@@ -1,4 +1,4 @@
-import { WalletConnectConnector } from '@wagmi/connectors/walletConnect'
+import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect'
 import type { Chain, Connector } from '@wagmi/core'
 import { InjectedConnector } from '@wagmi/core'
 import { jsonRpcProvider } from '@wagmi/core/providers/jsonRpc'


### PR DESCRIPTION
We were having the following issue while upgrading to `2.6.1`.
![image](https://github.com/WalletConnect/web3modal/assets/9066191/db3372d9-67d7-4389-99dd-ebc736c7504c)

Updating this import fixed the issue for us.

# Breaking Changes

# Changes

- fix: import in @web3modal/ethereum

# Associated Issues

There is no reported issue