### PR TITLE
reduce search threshold to 1 character

### DIFF
--- a/packages/ui/src/views/w3m-wallet-explorer-view/index.ts
+++ b/packages/ui/src/views/w3m-wallet-explorer-view/index.ts
@@ -100,7 +100,7 @@ export class W3mWalletExplorerView extends LitElement {
   }
 
   private readonly searchDebounce = UiUtil.debounce((value: string) => {
-    if (value.length >= 3) {
+    if (value.length >= 1) {
       this.firstFetch = true
       this.endReached = false
       this.search = value


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: reduce search threshold to 1 character to allow search wallets with just 2 chars in their names
- chore:

# Associated Issues

closes #1144 