### PR TITLE
[v3] Simplify and make account and network controllers reactive

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,10 +6,7 @@ export { RouterController } from './src/controllers/RouterController'
 export type { RouterControllerState } from './src/controllers/RouterController'
 
 export { AccountController } from './src/controllers/AccountController'
-export type {
-  AccountControllerClient,
-  AccountControllerState
-} from './src/controllers/AccountController'
+export type { AccountControllerState } from './src/controllers/AccountController'
 
 export { NetworkController } from './src/controllers/NetworkController'
 export type {

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -44,6 +44,10 @@ export const AccountController = {
     this.state.address = await this._getClient().getAddress()
   },
 
+  setAddress(address: AccountControllerState['address']) {
+    this.state.address = address
+  },
+
   async getBalance(address: AccountControllerState['address']) {
     this.state.balance = await this._getClient().getBalance(address)
   },

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -1,20 +1,8 @@
-import { proxy, ref } from 'valtio/vanilla'
+import { proxy } from 'valtio/vanilla'
 import type { CaipAddress } from '../utils/TypeUtils'
 
 // -- Types --------------------------------------------- //
-export interface AccountControllerClient {
-  getAddress: () => Promise<AccountControllerState['address']>
-  getBalance: (
-    address: AccountControllerState['address']
-  ) => Promise<AccountControllerState['balance']>
-  getProfile?: (address: AccountControllerState['address']) => Promise<{
-    name: AccountControllerState['profileName']
-    image: AccountControllerState['profileImage']
-  }>
-}
-
 export interface AccountControllerState {
-  _client?: AccountControllerClient
   address?: CaipAddress
   balance?: string
   profileName?: string
@@ -28,33 +16,19 @@ const state = proxy<AccountControllerState>({})
 export const AccountController = {
   state,
 
-  _getClient() {
-    if (!state._client) {
-      throw new Error('AccountController client not set')
-    }
-
-    return state._client
-  },
-
-  setClient(client: AccountControllerClient) {
-    state._client = ref(client)
-  },
-
-  async getAddress() {
-    this.state.address = await this._getClient().getAddress()
-  },
-
   setAddress(address: AccountControllerState['address']) {
     this.state.address = address
   },
 
-  async getBalance(address: AccountControllerState['address']) {
-    this.state.balance = await this._getClient().getBalance(address)
+  setBalance(balance: AccountControllerState['balance']) {
+    this.state.balance = balance
   },
 
-  async getProfile(address: AccountControllerState['address']) {
-    const profile = await this._getClient().getProfile?.(address)
-    this.state.profileName = profile?.name
-    this.state.profileImage = profile?.image
+  setProfileName(profileName: AccountControllerState['profileName']) {
+    this.state.profileName = profileName
+  },
+
+  setProfileImage(profileImage: AccountControllerState['profileImage']) {
+    this.state.profileImage = profileImage
   }
 }

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -3,7 +3,7 @@ import type { CaipChainId } from '../utils/TypeUtils'
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
-  getActiveNetwork: () => Promise<NetworkControllerState['network']>
+  getNetwork: () => Promise<NetworkControllerState['network']>
   getRequestedNetworks: () => Promise<NetworkControllerState['requestedNetworks']>
   getApprovedNetworks: () => Promise<NetworkControllerState['approvedNetworks']>
   switchActiveNetwork: (network: NetworkControllerState['network']) => Promise<void>
@@ -36,7 +36,7 @@ export const NetworkController = {
   },
 
   async getNetwork() {
-    state.network = await this._getClient().getActiveNetwork()
+    state.network = await this._getClient().getNetwork()
   },
 
   setNetwork(network: NetworkControllerState['network']) {

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -3,10 +3,7 @@ import type { CaipChainId } from '../utils/TypeUtils'
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
-  getNetwork: () => Promise<NetworkControllerState['network']>
-  getRequestedNetworks: () => Promise<NetworkControllerState['requestedNetworks']>
-  getApprovedNetworks: () => Promise<NetworkControllerState['approvedNetworks']>
-  switchActiveNetwork: (network: NetworkControllerState['network']) => Promise<void>
+  switchNetwork: (network: NetworkControllerState['network']) => Promise<void>
 }
 
 export interface NetworkControllerState {
@@ -35,24 +32,20 @@ export const NetworkController = {
     state._client = ref(client)
   },
 
-  async getNetwork() {
-    state.network = await this._getClient().getNetwork()
-  },
-
   setNetwork(network: NetworkControllerState['network']) {
     state.network = network
   },
 
-  async getRequestedNetworks() {
-    state.requestedNetworks = await this._getClient().getRequestedNetworks()
+  setRequestedNetworks(requestedNetworks: NetworkControllerState['requestedNetworks']) {
+    state.requestedNetworks = requestedNetworks
   },
 
-  async getApprovedNetworks() {
-    state.approvedNetworks = await this._getClient().getApprovedNetworks()
+  setApprovedNetworks(approvedNetworks: NetworkControllerState['approvedNetworks']) {
+    state.approvedNetworks = approvedNetworks
   },
 
   async switchActiveNetwork(network: NetworkControllerState['network']) {
-    await this._getClient().switchActiveNetwork(network)
+    await this._getClient().switchNetwork(network)
     state.network = network
   }
 }

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -3,15 +3,15 @@ import type { CaipChainId } from '../utils/TypeUtils'
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
-  getActiveNetwork: () => Promise<NetworkControllerState['activeNetwork']>
+  getActiveNetwork: () => Promise<NetworkControllerState['network']>
   getRequestedNetworks: () => Promise<NetworkControllerState['requestedNetworks']>
   getApprovedNetworks: () => Promise<NetworkControllerState['approvedNetworks']>
-  switchActiveNetwork: (network: NetworkControllerState['activeNetwork']) => Promise<void>
+  switchActiveNetwork: (network: NetworkControllerState['network']) => Promise<void>
 }
 
 export interface NetworkControllerState {
   _client?: NetworkControllerClient
-  activeNetwork?: CaipChainId
+  network?: CaipChainId
   requestedNetworks?: CaipChainId[]
   approvedNetworks?: CaipChainId[]
 }
@@ -35,8 +35,12 @@ export const NetworkController = {
     state._client = ref(client)
   },
 
-  async getActiveNetwork() {
-    state.activeNetwork = await this._getClient().getActiveNetwork()
+  async getNetwork() {
+    state.network = await this._getClient().getActiveNetwork()
+  },
+
+  setNetwork(network: NetworkControllerState['network']) {
+    state.network = network
   },
 
   async getRequestedNetworks() {
@@ -47,8 +51,8 @@ export const NetworkController = {
     state.approvedNetworks = await this._getClient().getApprovedNetworks()
   },
 
-  async switchActiveNetwork(network: Required<NetworkControllerState['activeNetwork']>) {
+  async switchActiveNetwork(network: NetworkControllerState['network']) {
     await this._getClient().switchActiveNetwork(network)
-    state.activeNetwork = network
+    state.network = network
   }
 }

--- a/packages/core/tests/controllers/AccountController.test.ts
+++ b/packages/core/tests/controllers/AccountController.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import type { AccountControllerClient } from '../../index'
 import { AccountController } from '../../index'
 
 // -- Setup --------------------------------------------------------------------
@@ -8,54 +7,29 @@ const balance = '0.100'
 const profileName = 'john.eth'
 const profileImage = 'https://ipfs.com/0x123.png'
 
-const client: AccountControllerClient = {
-  getAddress: async () => Promise.resolve(address),
-  getBalance: async _address => Promise.resolve(balance),
-  getProfile: async _address => Promise.resolve({ name: profileName, image: profileImage })
-}
-
-const partialClient: AccountControllerClient = {
-  getAddress: async () => Promise.resolve(address),
-  getBalance: async () => Promise.resolve(balance)
-}
-
 // -- Tests --------------------------------------------------------------------
 describe('ModalController', () => {
-  it('should throw if client not set', () => {
-    expect(AccountController._getClient).toThrow('AccountController client not set')
-  })
-
   it('should have valid default state', () => {
-    AccountController.setClient(client)
-
-    expect(AccountController.state).toEqual({
-      _client: AccountController._getClient()
-    })
-  })
-
-  it('should update state correctly on getAddress()', async () => {
-    await AccountController.getAddress()
-    expect(AccountController.state.address).toEqual(address)
+    expect(AccountController.state).toEqual({})
   })
 
   it('should update state correctly on setAddress()', () => {
-    AccountController.setAddress('eip155:1:0x124')
-    expect(AccountController.state.address).toEqual('eip155:1:0x124')
+    AccountController.setAddress(address)
+    expect(AccountController.state.address).toEqual(address)
   })
 
-  it('should update state correctly on getBalance()', async () => {
-    await AccountController.getBalance(AccountController.state.address)
+  it('should update state correctly on setBalance()', () => {
+    AccountController.setBalance(balance)
     expect(AccountController.state.balance).toEqual(balance)
   })
 
-  it('should update state correctly on getProfile()', async () => {
-    await AccountController.getProfile(AccountController.state.address)
+  it('should update state correctly on setProfileName()', () => {
+    AccountController.setProfileName(profileName)
     expect(AccountController.state.profileName).toEqual(profileName)
-    expect(AccountController.state.profileImage).toEqual(profileImage)
   })
 
-  it('when optional methods are undefined', async () => {
-    AccountController.setClient(partialClient)
-    await AccountController.getProfile(AccountController.state.address)
+  it('should update state correctly on setProfileImage()', () => {
+    AccountController.setProfileImage(profileImage)
+    expect(AccountController.state.profileImage).toEqual(profileImage)
   })
 })

--- a/packages/core/tests/controllers/AccountController.test.ts
+++ b/packages/core/tests/controllers/AccountController.test.ts
@@ -38,6 +38,11 @@ describe('ModalController', () => {
     expect(AccountController.state.address).toEqual(address)
   })
 
+  it('should update state correctly on setAddress()', () => {
+    AccountController.setAddress('eip155:1:0x124')
+    expect(AccountController.state.address).toEqual('eip155:1:0x124')
+  })
+
   it('should update state correctly on getBalance()', async () => {
     await AccountController.getBalance(AccountController.state.address)
     expect(AccountController.state.balance).toEqual(balance)
@@ -51,7 +56,6 @@ describe('ModalController', () => {
 
   it('when optional methods are undefined', async () => {
     AccountController.setClient(partialClient)
-
     await AccountController.getProfile(AccountController.state.address)
   })
 })

--- a/packages/core/tests/controllers/NetworkController.test.ts
+++ b/packages/core/tests/controllers/NetworkController.test.ts
@@ -3,12 +3,12 @@ import type { CaipChainId, NetworkControllerClient } from '../../index'
 import { NetworkController } from '../../index'
 
 // -- Setup --------------------------------------------------------------------
-const activeNetwork = 'eip155:1'
+const network = 'eip155:1'
 const requestedNetworks = ['eip155:1', 'eip155:2', 'eip155:3'] as CaipChainId[]
 const approvedNetworks = ['eip155:1', 'eip155:2'] as CaipChainId[]
 
 const client: NetworkControllerClient = {
-  getActiveNetwork: async () => Promise.resolve(activeNetwork),
+  getActiveNetwork: async () => Promise.resolve(network),
   getRequestedNetworks: async () => Promise.resolve(requestedNetworks),
   getApprovedNetworks: async () => Promise.resolve(approvedNetworks),
   switchActiveNetwork: async _network => Promise.resolve()
@@ -38,13 +38,18 @@ describe('ModalController', () => {
     expect(NetworkController.state.approvedNetworks).toEqual(approvedNetworks)
   })
 
-  it('should update state correctly on switchActiveNetwork()', async () => {
-    await NetworkController.switchActiveNetwork(activeNetwork)
-    expect(NetworkController.state.activeNetwork).toEqual(activeNetwork)
+  it('should update state correctly on switchNetwork()', async () => {
+    await NetworkController.switchActiveNetwork(network)
+    expect(NetworkController.state.network).toEqual(network)
   })
 
-  it('should update state correctly on getActiveNetwork()', async () => {
-    await NetworkController.getActiveNetwork()
-    expect(NetworkController.state.activeNetwork).toEqual(activeNetwork)
+  it('should update state correctly on getNetwork()', async () => {
+    await NetworkController.getNetwork()
+    expect(NetworkController.state.network).toEqual(network)
+  })
+
+  it('should update state correctly on setActiveNetwork()', () => {
+    NetworkController.setNetwork('eip155:2')
+    expect(NetworkController.state.network).toEqual('eip155:2')
   })
 })

--- a/packages/core/tests/controllers/NetworkController.test.ts
+++ b/packages/core/tests/controllers/NetworkController.test.ts
@@ -8,7 +8,7 @@ const requestedNetworks = ['eip155:1', 'eip155:2', 'eip155:3'] as CaipChainId[]
 const approvedNetworks = ['eip155:1', 'eip155:2'] as CaipChainId[]
 
 const client: NetworkControllerClient = {
-  getActiveNetwork: async () => Promise.resolve(network),
+  getNetwork: async () => Promise.resolve(network),
   getRequestedNetworks: async () => Promise.resolve(requestedNetworks),
   getApprovedNetworks: async () => Promise.resolve(approvedNetworks),
   switchActiveNetwork: async _network => Promise.resolve()

--- a/packages/core/tests/controllers/NetworkController.test.ts
+++ b/packages/core/tests/controllers/NetworkController.test.ts
@@ -8,10 +8,7 @@ const requestedNetworks = ['eip155:1', 'eip155:2', 'eip155:3'] as CaipChainId[]
 const approvedNetworks = ['eip155:1', 'eip155:2'] as CaipChainId[]
 
 const client: NetworkControllerClient = {
-  getNetwork: async () => Promise.resolve(network),
-  getRequestedNetworks: async () => Promise.resolve(requestedNetworks),
-  getApprovedNetworks: async () => Promise.resolve(approvedNetworks),
-  switchActiveNetwork: async _network => Promise.resolve()
+  switchNetwork: async _network => Promise.resolve()
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -28,13 +25,13 @@ describe('ModalController', () => {
     })
   })
 
-  it('should update state correctly on getRequestedNetworks()', async () => {
-    await NetworkController.getRequestedNetworks()
+  it('should update state correctly on setRequestedNetworks()', () => {
+    NetworkController.setRequestedNetworks(requestedNetworks)
     expect(NetworkController.state.requestedNetworks).toEqual(requestedNetworks)
   })
 
-  it('should update state correctly on getApprovedNetworks()', async () => {
-    await NetworkController.getApprovedNetworks()
+  it('should update state correctly on setApprovedNetworks()', () => {
+    NetworkController.setApprovedNetworks(approvedNetworks)
     expect(NetworkController.state.approvedNetworks).toEqual(approvedNetworks)
   })
 
@@ -43,13 +40,8 @@ describe('ModalController', () => {
     expect(NetworkController.state.network).toEqual(network)
   })
 
-  it('should update state correctly on getNetwork()', async () => {
-    await NetworkController.getNetwork()
+  it('should update state correctly on setNetwork()', () => {
+    NetworkController.setNetwork(network)
     expect(NetworkController.state.network).toEqual(network)
-  })
-
-  it('should update state correctly on setActiveNetwork()', () => {
-    NetworkController.setNetwork('eip155:2')
-    expect(NetworkController.state.network).toEqual('eip155:2')
   })
 })

--- a/packages/scaffold-html/index.ts
+++ b/packages/scaffold-html/index.ts
@@ -8,7 +8,6 @@ export * from './src/partials/w3m-header'
 export { Web3ModalScaffoldHtml } from './src/client'
 
 export type {
-  AccountControllerClient,
   CaipAddress,
   CaipChainId,
   ConnectionControllerClient,

--- a/packages/scaffold-html/src/client.ts
+++ b/packages/scaffold-html/src/client.ts
@@ -1,10 +1,4 @@
-import type {
-  AccountControllerClient,
-  AccountControllerState,
-  ConnectionControllerClient,
-  NetworkControllerClient,
-  NetworkControllerState
-} from '@web3modal/core'
+import type { ConnectionControllerClient, NetworkControllerClient } from '@web3modal/core'
 import {
   AccountController,
   ConnectionController,
@@ -15,50 +9,60 @@ import {
 
 // -- Types ---------------------------------------------------------------------
 interface Options {
-  accountControllerClient: AccountControllerClient
   networkControllerClient: NetworkControllerClient
   connectionControllerClient: ConnectionControllerClient
 }
 
 // -- Client --------------------------------------------------------------------
 export class Web3ModalScaffoldHtml {
-  #initPromise?: Promise<void> = undefined
+  private initPromise?: Promise<void> = undefined
 
   public constructor(options: Options) {
-    this.#setControllerClients(options)
-    this.#initOrContinue()
+    this.setControllerClients(options)
+    this.initOrContinue()
   }
 
   // -- Public -------------------------------------------------------------------
   public async open() {
-    await this.#initOrContinue()
+    await this.initOrContinue()
     ModalController.open()
   }
 
   public async close() {
-    await this.#initOrContinue()
+    await this.initOrContinue()
     ModalController.close()
   }
 
-  // -- Internal -----------------------------------------------------------------
-  public _setAddress(address: AccountControllerState['address']) {
+  // -- Protected ----------------------------------------------------------------
+  protected setAddress: (typeof AccountController)['setAddress'] = address => {
     AccountController.setAddress(address)
   }
 
-  public _setNetwork(network: NetworkControllerState['network']) {
+  protected setBalance: (typeof AccountController)['setBalance'] = balance => {
+    AccountController.setBalance(balance)
+  }
+
+  protected setProfileName: (typeof AccountController)['setProfileName'] = profileName => {
+    AccountController.setProfileName(profileName)
+  }
+
+  protected setProfileImage: (typeof AccountController)['setProfileImage'] = profileImage => {
+    AccountController.setProfileImage(profileImage)
+  }
+
+  protected setNetwork: (typeof NetworkController)['setNetwork'] = network => {
     NetworkController.setNetwork(network)
   }
 
   // -- Private ------------------------------------------------------------------
-  #setControllerClients(options: Options) {
-    AccountController.setClient(options.accountControllerClient)
+  private setControllerClients(options: Options) {
     NetworkController.setClient(options.networkControllerClient)
     ConnectionController.setClient(options.connectionControllerClient)
   }
 
-  async #initOrContinue() {
-    if (!this.#initPromise && HelperUtil.isClient()) {
-      this.#initPromise = new Promise<void>(async resolve => {
+  private async initOrContinue() {
+    if (!this.initPromise && HelperUtil.isClient()) {
+      this.initPromise = new Promise<void>(async resolve => {
         await Promise.all([import('@web3modal/ui'), import('./modal/w3m-modal')])
         const modal = document.createElement('w3m-modal')
         document.body.insertAdjacentElement('beforeend', modal)
@@ -66,6 +70,6 @@ export class Web3ModalScaffoldHtml {
       })
     }
 
-    return this.#initPromise
+    return this.initPromise
   }
 }

--- a/packages/scaffold-html/src/client.ts
+++ b/packages/scaffold-html/src/client.ts
@@ -1,7 +1,9 @@
 import type {
   AccountControllerClient,
+  AccountControllerState,
   ConnectionControllerClient,
-  NetworkControllerClient
+  NetworkControllerClient,
+  NetworkControllerState
 } from '@web3modal/core'
 import {
   AccountController,
@@ -36,6 +38,15 @@ export class Web3ModalScaffoldHtml {
   public async close() {
     await this.#initOrContinue()
     ModalController.close()
+  }
+
+  // -- Internal -----------------------------------------------------------------
+  public _setAddress(address: AccountControllerState['address']) {
+    AccountController.setAddress(address)
+  }
+
+  public _setNetwork(network: NetworkControllerState['network']) {
+    NetworkController.setNetwork(network)
   }
 
   // -- Private ------------------------------------------------------------------

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -160,24 +160,19 @@ export class Web3Modal extends Web3ModalScaffoldHtml {
     })
 
     watchAccount(({ address }) => {
-      if (!address) {
-        throw new Error('wagmi:watchAccount - address is undefined')
-      }
       const { chain } = getNetwork()
-      if (!chain) {
-        throw new Error('wagmi:watchAccount - chain is undefined')
+      if (address && chain) {
+        const caipAddress: CaipAddress = `${NAMESPACE}:${chain.id}:${address}`
+        super._setAddress(caipAddress)
       }
-      const caipAddress: CaipAddress = `${NAMESPACE}:${chain.id}:${address}`
-      super._setAddress(caipAddress)
     })
 
     watchNetwork(({ chain }) => {
-      if (!chain) {
-        throw new Error('wagmi:watchNetwork - chain is undefined')
+      if (chain) {
+        const chainId = String(chain.id)
+        const caipChainId: CaipChainId = `${NAMESPACE}:${chainId}`
+        super._setNetwork(caipChainId)
       }
-      const chainId = String(chain.id)
-      const caipChainId: CaipChainId = `${NAMESPACE}:${chainId}`
-      super._setNetwork(caipChainId)
     })
   }
 }

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -6,7 +6,9 @@ import {
   fetchEnsName,
   getAccount,
   getNetwork,
-  switchNetwork
+  switchNetwork,
+  watchAccount,
+  watchNetwork
 } from '@wagmi/core'
 import type {
   AccountControllerClient,
@@ -155,6 +157,27 @@ export class Web3Modal extends Web3ModalScaffoldHtml {
       accountControllerClient,
       networkControllerClient,
       connectionControllerClient
+    })
+
+    watchAccount(({ address }) => {
+      if (!address) {
+        throw new Error('wagmi:watchAccount - address is undefined')
+      }
+      const { chain } = getNetwork()
+      if (!chain) {
+        throw new Error('wagmi:watchAccount - chain is undefined')
+      }
+      const caipAddress: CaipAddress = `${NAMESPACE}:${chain.id}:${address}`
+      super._setAddress(caipAddress)
+    })
+
+    watchNetwork(({ chain }) => {
+      if (!chain) {
+        throw new Error('wagmi:watchNetwork - chain is undefined')
+      }
+      const chainId = String(chain.id)
+      const caipChainId: CaipChainId = `${NAMESPACE}:${chainId}`
+      super._setNetwork(caipChainId)
     })
   }
 }

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -84,10 +84,10 @@ export class Web3Modal extends Web3ModalScaffoldHtml {
     }
 
     const networkControllerClient: NetworkControllerClient = {
-      async getActiveNetwork() {
+      async getNetwork() {
         const { chain } = getNetwork()
         if (!chain) {
-          throw new Error('wagmi:networkControllerClient:getActiveNetwork - chain is undefined')
+          throw new Error('wagmi:networkControllerClient:getNetwork - chain is undefined')
         }
         const chainId = String(chain.id)
         const caipChainId: CaipChainId = `${NAMESPACE}:${chainId}`


### PR DESCRIPTION
# Changes

Simplified account and network controllers to where they mostly have `set` methods which are called from client implementation i.e wagmi. This means that in scaffold we just need to "react" to changes when they happen on state, will reduce logic in there substantially latter on.
