### PR TITLE
Fix bug with deeplink choice storage

### DIFF
--- a/packages/core/src/controllers/ModalCtrl.ts
+++ b/packages/core/src/controllers/ModalCtrl.ts
@@ -6,6 +6,7 @@ import { ConfigCtrl } from './ConfigCtrl'
 import { OptionsCtrl } from './OptionsCtrl'
 import { RouterCtrl } from './RouterCtrl'
 import { WcConnectionCtrl } from './WcConnectionCtrl'
+import { CoreUtil } from '../utils/CoreUtil';
 
 // -- types -------------------------------------------------------- //
 export interface OpenOptions {
@@ -31,6 +32,7 @@ export const ModalCtrl = {
       const { isConnected } = AccountCtrl.state
       const { enableNetworkView } = ConfigCtrl.state
       WcConnectionCtrl.setPairingEnabled(true)
+      CoreUtil.removeWalletConnectDeepLink();
 
       if (options?.route) {
         RouterCtrl.reset(options.route)


### PR DESCRIPTION
# Breaking Changes

None.

# Changes

- fix: Fix a bug that was causing `CoreUtil.WALLETCONNECT_DEEPLINK_CHOICE` to remain at stale value and cause buggy behavior in certain modal usage patterns.

# Associated Issues

resolve #1227