### PR TITLE
fix: modal background adds blur effect

### DIFF
--- a/packages/scaffold/src/modal/w3m-modal/styles.ts
+++ b/packages/scaffold/src/modal/w3m-modal/styles.ts
@@ -28,6 +28,7 @@ export default css`
     animation-fill-mode: backwards;
     animation-timing-function: var(--wui-ease-out-power-2);
     outline: none;
+    backdrop-filter: blur(20px);
   }
 
   @media (max-width: 430px) {


### PR DESCRIPTION
# Breaking Changes

Chrome version lower than v 111 does not support color mix syntax
Chrome 版本低于v111不支持 color-mix 语法

# Changes

- feat:
- fix:
- chore:

# Associated Issues

closes #...

old
![old](https://github.com/WalletConnect/web3modal/assets/19625243/99f8d5e0-5f53-481d-ae23-bad0b4b02f12)

new
![new](https://github.com/WalletConnect/web3modal/assets/19625243/3b2b2398-e050-4512-9e0d-15df5c199fd1)
