### PR TITLE
tag 3.0.2, connectorImages option

### DIFF
--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apps/gallery",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/ui": "3.0.1",
+    "@web3modal/ui": "3.0.2",
     "lit": "2.8.0",
     "storybook": "7.4.5"
   },

--- a/apps/laboratory/package.json
+++ b/apps/laboratory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apps/laboratory",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "dev:laboratory": "next dev",
@@ -11,9 +11,9 @@
     "@chakra-ui/react": "2.8.1",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
-    "@sentry/browser": "7.71.0",
-    "@sentry/react": "7.71.0",
-    "@web3modal/wagmi": "3.0.1",
+    "@sentry/browser": "7.72.0",
+    "@sentry/react": "7.72.0",
+    "@web3modal/wagmi": "3.0.2",
     "framer-motion": "10.16.4",
     "next": "13.5.3",
     "react-icons": "4.11.0",

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/react-wagmi",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "scripts": {
     "dev:example": "vite --port 3001",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/wagmi": "3.0.1"
+    "@web3modal/wagmi": "3.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.1.0"

--- a/examples/vue-wagmi/package.json
+++ b/examples/vue-wagmi/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/vue-wagmi",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "scripts": {
     "dev:example": "vite --port 3002",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/wagmi": "3.0.1"
+    "@web3modal/wagmi": "3.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "4.3.4"

--- a/lerna.json
+++ b/lerna.json
@@ -9,6 +9,6 @@
     "apps/*",
     "examples/*"
   ],
-  "version": "3.0.1",
+  "version": "3.0.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "examples/*"
       ],
       "devDependencies": {
-        "@types/react": "18.2.22",
-        "@types/react-dom": "18.2.7",
+        "@types/react": "18.2.23",
+        "@types/react-dom": "18.2.8",
         "@typescript-eslint/eslint-plugin": "6.7.3",
         "@typescript-eslint/parser": "6.7.3",
         "danger": "11.3.0",
@@ -40,9 +40,9 @@
     },
     "apps/gallery": {
       "name": "@apps/gallery",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
-        "@web3modal/ui": "3.0.1",
+        "@web3modal/ui": "3.0.2",
         "lit": "2.8.0",
         "storybook": "7.4.5"
       },
@@ -58,14 +58,14 @@
     },
     "apps/laboratory": {
       "name": "@apps/laboratory",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "@chakra-ui/react": "2.8.1",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
-        "@sentry/browser": "7.71.0",
-        "@sentry/react": "7.71.0",
-        "@web3modal/wagmi": "3.0.1",
+        "@sentry/browser": "7.72.0",
+        "@sentry/react": "7.72.0",
+        "@web3modal/wagmi": "3.0.2",
         "framer-motion": "10.16.4",
         "next": "13.5.3",
         "react-icons": "4.11.0",
@@ -74,9 +74,9 @@
     },
     "examples/react-wagmi": {
       "name": "@examples/react-wagmi",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
-        "@web3modal/wagmi": "3.0.1"
+        "@web3modal/wagmi": "3.0.2"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.1.0"
@@ -84,9 +84,9 @@
     },
     "examples/vue-wagmi": {
       "name": "@examples/vue-wagmi",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
-        "@web3modal/wagmi": "3.0.1"
+        "@web3modal/wagmi": "3.0.2"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "4.3.4"
@@ -3788,9 +3788,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.2.tgz",
-      "integrity": "sha512-0MGxAVt1m/ZK+LTJp/j0qF7Hz97D9O/FH9Ms3ltnyIdDD57cbb1ACIQTkbHvNXtWDv5TPq7w5Kq56+cNukbo7g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+      "integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -6587,13 +6587,13 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.71.0.tgz",
-      "integrity": "sha512-HRGsQOrA2Y3Ga+NTgCkTWO+qtU2SFTJ7t9pt/LR8Har9cvVcjLIlHNwPoDx6bVkICK3cGOF8ZtXVmLizVbXoAg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.72.0.tgz",
+      "integrity": "sha512-DToryaRSHk9R5RLgN4ktYEXZjQdqncOAWPqyyIurji8lIobXFRfmLtGL1wjoCK6sQNgWsjhSM9kXxwGnva1DNw==",
       "dependencies": {
-        "@sentry/core": "7.71.0",
-        "@sentry/types": "7.71.0",
-        "@sentry/utils": "7.71.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -6601,15 +6601,15 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.71.0.tgz",
-      "integrity": "sha512-7xggzwW2QW9g4Li1M3VQEsQX7AIeSlWnweTkkT+62t3AcLHD7URnNNU7SBAj7x+8F0WqkvMws0XXar51+rv/rw==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.72.0.tgz",
+      "integrity": "sha512-fcFDTzqhPd3VZAmmYW3KvBTBaEfrKjPmRhlAsfhkGWYLCHqVkNtzsFER4cmUNRGNxjyt9tcG3WlTTqgLRucycQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.71.0",
-        "@sentry/core": "7.71.0",
-        "@sentry/replay": "7.71.0",
-        "@sentry/types": "7.71.0",
-        "@sentry/utils": "7.71.0",
+        "@sentry-internal/tracing": "7.72.0",
+        "@sentry/core": "7.72.0",
+        "@sentry/replay": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -6617,12 +6617,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.71.0.tgz",
-      "integrity": "sha512-kZcWnzxzMxyNuCwq65owu0yGbY+C9QJhWFMDBsqmKK1/dSt0bdhNjf3VQW1dJLnWaQTk7rUTHEHGH8JSdV5EAg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.72.0.tgz",
+      "integrity": "sha512-G03JdQ5ZsFNRjcNNi+QvCjqOuBvYqU92Gs1T2iK3GE8dSBTu2khThydMpG4xrKZQLIpHOyiIhlFZiuPtZ66W8w==",
       "dependencies": {
-        "@sentry/types": "7.71.0",
-        "@sentry/utils": "7.71.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -6630,13 +6630,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.71.0.tgz",
-      "integrity": "sha512-ni9gofBaKJmTsJpQhefS2NDck0FSOSIp6DzHCx7+9ohrmosdjIk4WR/wFlRjwA5ack/4ctMt5dLV9OIhiDH1rg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.72.0.tgz",
+      "integrity": "sha512-BYFO3uyB9FfdUq05NtsS+OfU636HMZ7avbSEALo24x+OPuaD+fCByTdgxYVpDRYrBPa7lALYzCge0PDcGnGiig==",
       "dependencies": {
-        "@sentry/browser": "7.71.0",
-        "@sentry/types": "7.71.0",
-        "@sentry/utils": "7.71.0",
+        "@sentry/browser": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^2.4.1 || ^1.9.3"
       },
@@ -6648,32 +6648,32 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.71.0.tgz",
-      "integrity": "sha512-roB65ixEycAy1BrIJ3HOu7NLKo4EOBs6Q6xKEq5BvzjhDgvFXXq8X/lGriJXc9Q/hWIiDwTQ23yLuzVtPJRnCw==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.72.0.tgz",
+      "integrity": "sha512-dHH/mYCFBwJ/kYmL9L5KihjwQKcefiuvcH0otHSwKSpbbeEoM/BV+SHQoYGd6OMSYnL9fq1dHfF7Zo26p5Yu0Q==",
       "dependencies": {
-        "@sentry/core": "7.71.0",
-        "@sentry/types": "7.71.0",
-        "@sentry/utils": "7.71.0"
+        "@sentry/core": "7.72.0",
+        "@sentry/types": "7.72.0",
+        "@sentry/utils": "7.72.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.71.0.tgz",
-      "integrity": "sha512-30PRLZI1RoeWbLE9K7AHsRPWDH22CqC4WcLNeVmRfLC5m1vE1FHb53r98QSKFhLoONMPMVzDhZZgl4ZcC5mptQ==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.72.0.tgz",
+      "integrity": "sha512-g6u0mk62yGshx02rfFADIfyR/S9VXcf3RG2qQPuvykrWtOfN/BOTrZypF7I+MiqKwRW76r3Pcu2C/AB+6z9XQA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.71.0.tgz",
-      "integrity": "sha512-aS53l/E/5XsSJMOXHKvS0GlX4gZHBgNAMfhEB3f8rUIn5iLF2uu8lCA1uEvX6VB8b7q/Cg4WFTi6BiJ0hvJHQg==",
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.72.0.tgz",
+      "integrity": "sha512-o/MtqI7WJXuswidH0bSgBP40KN2lrnyQEIx5uoyJUJi/QEaboIsqbxU62vaFJpde8SYrbA+rTnP3J3ujF2gUag==",
       "dependencies": {
-        "@sentry/types": "7.71.0",
+        "@sentry/types": "7.72.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -7917,9 +7917,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/glob": {
-      "version": "10.3.9",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.9.tgz",
-      "integrity": "sha512-2tU/LKevAQvDVuVJ9pg9Yv9xcbSh+TqHuTaXTNbQwf+0kDl9Fm6bMovi4Nm5c8TVvfxo2LLcqCGtmO9KoJaGWg==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -9059,18 +9059,18 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -9205,14 +9205,14 @@
       }
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
-      "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
+      "version": "18.2.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
+      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -9221,18 +9221,18 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
-      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.1.tgz",
+      "integrity": "sha512-TiGnitEDxj2X0j+98Eqk5lv/Cij8oHd32bU4D/Yw6AOq7vvTk0gSD2GPj0G/HkvhMoVsdlhYF4yqqlyPBTM6Sg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -10874,9 +10874,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -11200,9 +11200,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.11",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
-      "integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
+      "integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
       "funding": [
         {
           "type": "opencollective",
@@ -11218,8 +11218,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001538",
-        "electron-to-chromium": "^1.4.526",
+        "caniuse-lite": "^1.0.30001539",
+        "electron-to-chromium": "^1.4.530",
         "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.13"
       },
@@ -11381,9 +11381,9 @@
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "10.3.9",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.9.tgz",
-      "integrity": "sha512-2tU/LKevAQvDVuVJ9pg9Yv9xcbSh+TqHuTaXTNbQwf+0kDl9Fm6bMovi4Nm5c8TVvfxo2LLcqCGtmO9KoJaGWg==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -11529,9 +11529,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001539",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
-      "integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==",
+      "version": "1.0.30001540",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001540.tgz",
+      "integrity": "sha512-9JL38jscuTJBTcuETxm8QLsFr/F6v0CYYTEU6r5+qSM98P2Q0Hmu0eG1dTG5GBUmywU3UlcVOUSIJYY47rdFSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -11548,13 +11548,13 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
-      "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.9.tgz",
+      "integrity": "sha512-tH8vhfA1CfuYMkALXj+wmZcqiwqOfshU9Gry+NYiiLqIddrobkBhALv6XD4yDz68qapphYI4vSaqhqAdThCAAA==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
+        "check-error": "^1.0.3",
         "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
@@ -11585,10 +11585,13 @@
       "dev": true
     },
     "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
         "node": "*"
       }
@@ -12789,9 +12792,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.529",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz",
-      "integrity": "sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A=="
+      "version": "1.4.531",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.531.tgz",
+      "integrity": "sha512-H6gi5E41Rn3/mhKlPaT1aIMg/71hTAqn0gYEllSuw9igNWtvQwu185jiCZoZD29n7Zukgh7GVZ3zGf0XvkhqjQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -20502,9 +20505,9 @@
       }
     },
     "node_modules/read-package-json/node_modules/glob": {
-      "version": "10.3.9",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.9.tgz",
-      "integrity": "sha512-2tU/LKevAQvDVuVJ9pg9Yv9xcbSh+TqHuTaXTNbQwf+0kDl9Fm6bMovi4Nm5c8TVvfxo2LLcqCGtmO9KoJaGWg==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -23582,7 +23585,7 @@
     },
     "packages/core": {
       "name": "@web3modal/core",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "valtio": "1.11.2"
@@ -23590,7 +23593,7 @@
     },
     "packages/polyfills": {
       "name": "@web3modal/polyfills",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3"
@@ -23621,17 +23624,17 @@
     },
     "packages/scaffold": {
       "name": "@web3modal/scaffold",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/core": "3.0.1",
-        "@web3modal/ui": "3.0.1",
+        "@web3modal/core": "3.0.2",
+        "@web3modal/ui": "3.0.2",
         "lit": "2.8.0"
       }
     },
     "packages/ui": {
       "name": "@web3modal/ui",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "2.8.0",
@@ -23645,11 +23648,11 @@
     },
     "packages/wagmi": {
       "name": "@web3modal/wagmi",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/polyfills": "3.0.1",
-        "@web3modal/scaffold": "3.0.1"
+        "@web3modal/polyfills": "3.0.2",
+        "@web3modal/scaffold": "3.0.2"
       },
       "optionalDependencies": {
         "react": ">=17",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "6.7.3",
     "@typescript-eslint/parser": "6.7.3",
-    "@types/react": "18.2.22",
-    "@types/react-dom": "18.2.7",
+    "@types/react": "18.2.23",
+    "@types/react-dom": "18.2.8",
     "eslint": "8.50.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-require-extensions": "0.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/core",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/polyfills",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/scaffold",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -16,8 +16,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/core": "3.0.1",
-    "@web3modal/ui": "3.0.1",
+    "@web3modal/core": "3.0.2",
+    "@web3modal/ui": "3.0.2",
     "lit": "2.8.0"
   },
   "keywords": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/ui",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/wagmi",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "main": "./dist/esm/exports/index.js",
   "types": "./dist/types/exports/index.d.ts",
@@ -43,8 +43,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/polyfills": "3.0.1",
-    "@web3modal/scaffold": "3.0.1"
+    "@web3modal/polyfills": "3.0.2",
+    "@web3modal/scaffold": "3.0.2"
   },
   "peerDependencies": {
     "@wagmi/core": ">=1",

--- a/packages/wagmi/src/utils/constants.ts
+++ b/packages/wagmi/src/utils/constants.ts
@@ -21,4 +21,4 @@ export const EIP6963_ANNOUNCE_EVENT = 'eip6963:announceProvider'
 export const EIP6963_REQUEST_EVENT = 'eip6963:requestProvider'
 
 // DO NOT REMOVE, SHOULD MATCH CORE PACKAGE VERSION
-export const VERSION = '3.0.1'
+export const VERSION = '3.0.2'


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat: `connectorImages` option allowing you to set or override connector images based on their id. Does not affect wallets fetched from web3modal api (recommended). You will only need to use this when you remove metamask that comes in the modal by default and replace it with wagmi connector. For example:
```ts
createWeb3Modal({
   connectorImages: {
      coinbaseWallet: 'https://images.mydapp.com/coinbase.png',
      metamask: 'https://images.mydapp.com/metamask.png'
   }
})
```
- chore: Update dependencies

# Associated Issues

N/A
