### PR TITLE
fixed @babel/traverse vulnerability CVE-2023-45133

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",


### PR DESCRIPTION
# Breaking Changes

fixed @babel/traverse v7.23.0 vulnerability, which is called CVE-2023-45133
please review https://github.com/advisories/GHSA-67hx-6x53-jw92

# Changes

- feat:
- fix: package-lock.json
- chore:
