### PR TITLE
3.2.0 alpha 1 

### DIFF
--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apps/gallery",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/ui": "3.2.0-f9b3ed8",
+    "@web3modal/ui": "3.2.0-alpha.1",
     "lit": "3.0.0",
     "storybook": "7.5.0"
   },

--- a/apps/laboratory/package.json
+++ b/apps/laboratory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apps/laboratory",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "dev:laboratory": "next dev",
@@ -13,8 +13,8 @@
     "@emotion/styled": "11.11.0",
     "@sentry/browser": "7.74.1",
     "@sentry/react": "7.74.1",
-    "@web3modal/ethers5": "3.2.0-f9b3ed8",
-    "@web3modal/wagmi": "3.2.0-f9b3ed8",
+    "@web3modal/ethers5": "3.2.0-alpha.1",
+    "@web3modal/wagmi": "3.2.0-alpha.1",
     "framer-motion": "10.16.4",
     "next": "13.5.6",
     "react-icons": "4.11.0",

--- a/examples/html-ethers5/package.json
+++ b/examples/html-ethers5/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/html-ethers5",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3003",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/ethers5": "3.2.0-f9b3ed8"
+    "@web3modal/ethers5": "3.2.0-alpha.1"
   }
 }

--- a/examples/html-wagmi/package.json
+++ b/examples/html-wagmi/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/html-wagmi",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3003",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/wagmi": "3.2.0-f9b3ed8"
+    "@web3modal/wagmi": "3.2.0-alpha.1"
   }
 }

--- a/examples/react-ethers5/package.json
+++ b/examples/react-ethers5/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/react-ethers5",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3001",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/ethers5": "3.2.0-f9b3ed8"
+    "@web3modal/ethers5": "3.2.0-alpha.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.1.0"

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/react-wagmi",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3001",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/wagmi": "3.2.0-f9b3ed8"
+    "@web3modal/wagmi": "3.2.0-alpha.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.1.0"

--- a/examples/vue-ethers5/package.json
+++ b/examples/vue-ethers5/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/vue-ethers5",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3002",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/ethers5": "3.2.0-f9b3ed8"
+    "@web3modal/ethers5": "3.2.0-alpha.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "4.4.0"

--- a/examples/vue-wagmi/package.json
+++ b/examples/vue-wagmi/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@examples/vue-wagmi",
   "private": true,
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "scripts": {
     "dev:example": "vite --port 3002",
     "build:examples": "vite build"
   },
   "dependencies": {
-    "@web3modal/wagmi": "3.2.0-f9b3ed8"
+    "@web3modal/wagmi": "3.2.0-alpha.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "4.4.0"

--- a/lerna.json
+++ b/lerna.json
@@ -13,6 +13,6 @@
     "apps/*",
     "examples/*"
   ],
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
     },
     "apps/gallery": {
       "name": "@apps/gallery",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/ui": "3.2.0-f9b3ed8",
+        "@web3modal/ui": "3.2.0-alpha.1",
         "lit": "3.0.0",
         "storybook": "7.5.0"
       },
@@ -73,15 +73,15 @@
     },
     "apps/laboratory": {
       "name": "@apps/laboratory",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
         "@chakra-ui/react": "2.8.1",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
         "@sentry/browser": "7.74.1",
         "@sentry/react": "7.74.1",
-        "@web3modal/ethers5": "3.2.0-f9b3ed8",
-        "@web3modal/wagmi": "3.2.0-f9b3ed8",
+        "@web3modal/ethers5": "3.2.0-alpha.1",
+        "@web3modal/wagmi": "3.2.0-alpha.1",
         "framer-motion": "10.16.4",
         "next": "13.5.6",
         "react-icons": "4.11.0",
@@ -90,23 +90,23 @@
     },
     "examples/html-ethers5": {
       "name": "@examples/html-ethers5",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/ethers5": "3.2.0-f9b3ed8"
+        "@web3modal/ethers5": "3.2.0-alpha.1"
       }
     },
     "examples/html-wagmi": {
       "name": "@examples/html-wagmi",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/wagmi": "3.2.0-f9b3ed8"
+        "@web3modal/wagmi": "3.2.0-alpha.1"
       }
     },
     "examples/react-ethers5": {
       "name": "@examples/react-ethers5",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/ethers5": "3.2.0-f9b3ed8"
+        "@web3modal/ethers5": "3.2.0-alpha.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.1.0"
@@ -114,9 +114,9 @@
     },
     "examples/react-wagmi": {
       "name": "@examples/react-wagmi",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/wagmi": "3.2.0-f9b3ed8"
+        "@web3modal/wagmi": "3.2.0-alpha.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.1.0"
@@ -124,9 +124,9 @@
     },
     "examples/vue-ethers5": {
       "name": "@examples/vue-ethers5",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/ethers5": "3.2.0-f9b3ed8"
+        "@web3modal/ethers5": "3.2.0-alpha.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "4.4.0"
@@ -134,9 +134,9 @@
     },
     "examples/vue-wagmi": {
       "name": "@examples/vue-wagmi",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "dependencies": {
-        "@web3modal/wagmi": "3.2.0-f9b3ed8"
+        "@web3modal/wagmi": "3.2.0-alpha.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "4.4.0"
@@ -24507,7 +24507,7 @@
     },
     "packages/core": {
       "name": "@web3modal/core",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "valtio": "1.11.2"
@@ -24515,16 +24515,16 @@
     },
     "packages/ethers5": {
       "name": "@web3modal/ethers5",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coinbase/wallet-sdk": "3.7.2",
         "@walletconnect/ethereum-provider": "2.10.2",
-        "@web3modal/polyfills": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold-react": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold-vue": "3.2.0-f9b3ed8",
-        "@web3modal/utils": "3.2.0-f9b3ed8",
+        "@web3modal/polyfills": "3.2.0-alpha.1",
+        "@web3modal/scaffold": "3.2.0-alpha.1",
+        "@web3modal/scaffold-react": "3.2.0-alpha.1",
+        "@web3modal/scaffold-vue": "3.2.0-alpha.1",
+        "@web3modal/utils": "3.2.0-alpha.1",
         "valtio": "1.11.2"
       },
       "optionalDependencies": {
@@ -24665,7 +24665,7 @@
     },
     "packages/polyfills": {
       "name": "@web3modal/polyfills",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3"
@@ -24696,20 +24696,20 @@
     },
     "packages/scaffold": {
       "name": "@web3modal/scaffold",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/core": "3.2.0-f9b3ed8",
-        "@web3modal/ui": "3.2.0-f9b3ed8",
+        "@web3modal/core": "3.2.0-alpha.1",
+        "@web3modal/ui": "3.2.0-alpha.1",
         "lit": "3.0.0"
       }
     },
     "packages/scaffold-react": {
       "name": "@web3modal/scaffold-react",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/scaffold": "3.2.0-f9b3ed8"
+        "@web3modal/scaffold": "3.2.0-alpha.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -24718,10 +24718,10 @@
     },
     "packages/scaffold-vue": {
       "name": "@web3modal/scaffold-vue",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/scaffold": "3.2.0-f9b3ed8"
+        "@web3modal/scaffold": "3.2.0-alpha.1"
       },
       "peerDependencies": {
         "vue": ">=3"
@@ -24739,7 +24739,7 @@
     },
     "packages/ui": {
       "name": "@web3modal/ui",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "3.0.0",
@@ -24763,23 +24763,23 @@
     },
     "packages/utils": {
       "name": "@web3modal/utils",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/polyfills": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold": "3.2.0-f9b3ed8"
+        "@web3modal/polyfills": "3.2.0-alpha.1",
+        "@web3modal/scaffold": "3.2.0-alpha.1"
       }
     },
     "packages/wagmi": {
       "name": "@web3modal/wagmi",
-      "version": "3.2.0-f9b3ed8",
+      "version": "3.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web3modal/polyfills": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold-react": "3.2.0-f9b3ed8",
-        "@web3modal/scaffold-vue": "3.2.0-f9b3ed8",
-        "@web3modal/utils": "3.2.0-f9b3ed8"
+        "@web3modal/polyfills": "3.2.0-alpha.1",
+        "@web3modal/scaffold": "3.2.0-alpha.1",
+        "@web3modal/scaffold-react": "3.2.0-alpha.1",
+        "@web3modal/scaffold-vue": "3.2.0-alpha.1",
+        "@web3modal/utils": "3.2.0-alpha.1"
       },
       "optionalDependencies": {
         "react": ">=17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/core",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/ethers5/package.json
+++ b/packages/ethers5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/ethers5",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/exports/index.js",
   "types": "./dist/types/exports/index.d.ts",
@@ -45,11 +45,11 @@
   "dependencies": {
     "@coinbase/wallet-sdk": "3.7.2",
     "@walletconnect/ethereum-provider": "2.10.2",
-    "@web3modal/polyfills": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold-react": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold-vue": "3.2.0-f9b3ed8",
-    "@web3modal/utils": "3.2.0-f9b3ed8",
+    "@web3modal/polyfills": "3.2.0-alpha.1",
+    "@web3modal/scaffold": "3.2.0-alpha.1",
+    "@web3modal/scaffold-react": "3.2.0-alpha.1",
+    "@web3modal/scaffold-vue": "3.2.0-alpha.1",
+    "@web3modal/utils": "3.2.0-alpha.1",
     "valtio": "1.11.2"
   },
   "peerDependencies": {

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/polyfills",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/scaffold-react/package.json
+++ b/packages/scaffold-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/scaffold-react",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/scaffold": "3.2.0-f9b3ed8"
+    "@web3modal/scaffold": "3.2.0-alpha.1"
   },
   "peerDependencies": {
     "react": ">=17",

--- a/packages/scaffold-vue/package.json
+++ b/packages/scaffold-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/scaffold-vue",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/scaffold": "3.2.0-f9b3ed8"
+    "@web3modal/scaffold": "3.2.0-alpha.1"
   },
   "peerDependencies": {
     "vue": ">=3"

--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/scaffold",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -16,8 +16,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/core": "3.2.0-f9b3ed8",
-    "@web3modal/ui": "3.2.0-f9b3ed8",
+    "@web3modal/core": "3.2.0-alpha.1",
+    "@web3modal/ui": "3.2.0-alpha.1",
     "lit": "3.0.0"
   },
   "keywords": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/ui",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/utils",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -16,8 +16,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/polyfills": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold": "3.2.0-f9b3ed8"
+    "@web3modal/polyfills": "3.2.0-alpha.1",
+    "@web3modal/scaffold": "3.2.0-alpha.1"
   },
   "keywords": [
     "web3",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/wagmi",
-  "version": "3.2.0-f9b3ed8",
+  "version": "3.2.0-alpha.1",
   "type": "module",
   "main": "./dist/esm/exports/index.js",
   "types": "./dist/types/exports/index.d.ts",
@@ -43,11 +43,11 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@web3modal/polyfills": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold-react": "3.2.0-f9b3ed8",
-    "@web3modal/scaffold-vue": "3.2.0-f9b3ed8",
-    "@web3modal/utils": "3.2.0-f9b3ed8"
+    "@web3modal/polyfills": "3.2.0-alpha.1",
+    "@web3modal/scaffold": "3.2.0-alpha.1",
+    "@web3modal/scaffold-react": "3.2.0-alpha.1",
+    "@web3modal/scaffold-vue": "3.2.0-alpha.1",
+    "@web3modal/utils": "3.2.0-alpha.1"
   },
   "peerDependencies": {
     "@wagmi/core": ">=1",


### PR DESCRIPTION
# Ethers.js V5 Support 🧪

- `ethers.js V5` now supported by Web3Modal  
- support for `WalletConnectProvider`
- support for `InjectedProvider`
- support for `CoinbaseProvider`
- support for `EIP6963`
- added several hooks/compositions/getters 

# Changes

- feat: added new export to create Web3Modal with `ethers.js`
```ts
import { createWeb3Modal } from '@web3modal/ethers5'

const modal = createWeb3Modal({
  ethersConfig: defaultConfig({
    metadata: {
      name: 'Web3Modal',
      description: 'Web3Modal Laboratory',
      url: 'https://web3modal.com',
      icons: ['https://avatars.githubusercontent.com/u/37784886']
    },
    defaultChainId: 1,
    rpcUrl: 'https://cloudflare-eth.com'
  }),
  chains,
  projectId,
  enableAnalytics: true
})
```
- feat: added `react` hooks to get several properties
```ts
import { useWeb3ModalSigner, useWeb3ModalAccount } from '@web3modal/ethers5/react'

const { signer, walletProvider, walletProviderType } = useWeb3ModalSigner()
const { address, chainId, isConnected } = useWeb3ModalAccount()
```
- feat: added `vue` compositions to get several properties
```ts
import { useWeb3ModalSigner, useWeb3ModalAccount } from '@web3modal/ethers5/vue'

const { signer,  walletProvider, walletProviderType } = useWeb3ModalSigner()
const { address, chainId, isConnected } = useWeb3ModalAccount()
```
- feat: added  `vanillaJS` getters to get several properties
```ts
modal.getSigner() // get last signer
modal.getWalletProvider() // get last walletProvider
modal.getWalletProviderType() // get last walletProviderType
modal.getAddress() // get last address
modal.getChainId() // get last chainId
modal.getIsConnected() // get last isConnected
modal.subscribeProvider(state => console.log(state)) // subscribe to all above properties

```
- feat: Created `utils` package to store shared `constants`, `presets` and `helpers`
- feat: Created `scaffold-react` package to store shared react hooks
- feat: Created `scaffold-vue` package to store shared vue compositions
- feat: Created new `react`, `vue` and `html` examples with `ethers.js`
- chore: Update dependencies


