### PR TITLE
[Fix] defaultWagmiCoreConfig.ts

### DIFF
--- a/packages/wagmi/src/utils/defaultWagmiCoreConfig.ts
+++ b/packages/wagmi/src/utils/defaultWagmiCoreConfig.ts
@@ -21,14 +21,14 @@ export interface ConfigOptions {
   chains: Chain[]
 }
 
-export function defaultWagmiConfig({ projectId, chains, metadata }: ConfigOptions) {
+export function defaultWagmiConfig({ projectId, chains, metadata, autoConnect = true }: ConfigOptions) {
   const { publicClient } = configureChains(chains, [
     walletConnectProvider({ projectId }),
     publicProvider()
   ])
 
   return createConfig({
-    autoConnect: true,
+    autoConnect,
     connectors: [
       new WalletConnectConnector({ chains, options: { projectId, showQrModal: false, metadata } }),
       new EIP6963Connector({ chains }),


### PR DESCRIPTION
Set autoConnect as a param and default to true.

# Breaking Changes

N/A

# Changes

- feat:
- fix: set autoConnect as a default true param
- chore:

# Associated Issues

closes #1488
