### PR TITLE
fix: remove EIP6963 connector from localStore on account change

### DIFF
--- a/packages/wagmi/src/connectors/EIP6963Connector.ts
+++ b/packages/wagmi/src/connectors/EIP6963Connector.ts
@@ -55,10 +55,11 @@ export class EIP6963Connector extends InjectedConnector {
     if (accounts.length === 0) {
       this.storage?.removeItem(connectedRdnsKey)
       this.emit('disconnect')
-    } else
+    } else if (accounts[0]) {
       this.emit('change', {
-        account: getAddress(accounts[0] as string)
+        account: getAddress(accounts[0])
       })
+    }
   }
 
   public override async disconnect() {

--- a/packages/wagmi/src/connectors/EIP6963Connector.ts
+++ b/packages/wagmi/src/connectors/EIP6963Connector.ts
@@ -1,4 +1,4 @@
-import { type Chain, type WindowProvider } from '@wagmi/core'
+import type { Chain, WindowProvider } from '@wagmi/core'
 import { InjectedConnector } from '@wagmi/core/connectors/injected'
 import { getAddress } from 'viem'
 

--- a/packages/wagmi/src/connectors/EIP6963Connector.ts
+++ b/packages/wagmi/src/connectors/EIP6963Connector.ts
@@ -1,5 +1,6 @@
-import type { Chain, WindowProvider } from '@wagmi/core'
+import { type Chain, type WindowProvider } from '@wagmi/core'
 import { InjectedConnector } from '@wagmi/core/connectors/injected'
+import { getAddress } from 'viem'
 
 // -- Helpers ----------------------------------------------------------
 const connectedRdnsKey = 'connectedRdns'
@@ -48,6 +49,16 @@ export class EIP6963Connector extends InjectedConnector {
     }
 
     return data
+  }
+
+  protected override onAccountsChanged = (accounts: string[]) => {
+    if (accounts.length === 0) {
+      this.storage?.removeItem(connectedRdnsKey)
+      this.emit('disconnect')
+    } else
+      this.emit('change', {
+        account: getAddress(accounts[0] as string)
+      })
   }
 
   public override async disconnect() {


### PR DESCRIPTION
# Breaking Changes

Override onAccountChange function & added `this.storage?.removeItem(connectedRdnsKey)`


# Changes

- feat:
- fix: EIP6963 wallets were triggered on reload when were manually disconnected, this would trigger the accountsChanged event and clear the storage without calling the overriden `disconnect` function
- chore:

# Associated Issues

closes https://github.com/WalletConnect/web3modal/issues/1488
