### PR TITLE
fix: network image access in account button and account page

### DIFF
--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -8,10 +8,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
+  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
-import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
 
 import EthereumProvider from '@walletconnect/ethereum-provider'
@@ -35,7 +35,7 @@ import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider'
 // -- Types ---------------------------------------------------------------------
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   ethersConfig: ProviderType
-  siweConfig?: Web3ModalSIWEClient
+  siweConfig?: SIWEControllerClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -8,14 +8,12 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
-  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
+import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
-
 import EthereumProvider from '@walletconnect/ethereum-provider'
-
 import type {
   Address,
   Metadata,
@@ -35,7 +33,7 @@ import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider'
 // -- Types ---------------------------------------------------------------------
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   ethersConfig: ProviderType
-  siweConfig?: SIWEControllerClient
+  siweConfig?: Web3ModalSIWEClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/scaffold/src/modal/w3m-account-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-account-button/index.ts
@@ -1,6 +1,7 @@
 import {
   AccountController,
   AssetController,
+  AssetUtil,
   CoreHelperUtil,
   ModalController,
   NetworkController
@@ -66,7 +67,7 @@ export class W3mAccountButton extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    const networkImage = this.networkImages[this.network?.imageId ?? '']
+    const networkImage = AssetUtil.getNetworkImage(this.network)
     const showBalance = this.balance === 'show'
 
     return html`

--- a/packages/scaffold/src/modal/w3m-account-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-account-button/index.ts
@@ -1,6 +1,5 @@
 import {
   AccountController,
-  AssetController,
   AssetUtil,
   CoreHelperUtil,
   ModalController,
@@ -16,8 +15,6 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 export class W3mAccountButton extends LitElement {
   // -- Members ------------------------------------------- //
   private unsubscribe: (() => void)[] = []
-
-  private readonly networkImages = AssetController.state.networkImages
 
   // -- State & Properties -------------------------------- //
   @property({ type: Boolean }) public disabled?: WuiAccountButton['disabled'] = false

--- a/packages/scaffold/src/views/w3m-account-view/index.ts
+++ b/packages/scaffold/src/views/w3m-account-view/index.ts
@@ -1,6 +1,5 @@
 import {
   AccountController,
-  AssetController,
   ConnectionController,
   CoreHelperUtil,
   EventsController,
@@ -25,8 +24,6 @@ export class W3mAccountView extends LitElement {
 
   // -- Members -------------------------------------------- //
   private usubscribe: (() => void)[] = []
-
-  private readonly networkImages = AssetController.state.networkImages
 
   private readonly connectors = ConnectorController.state.connectors
 

--- a/packages/scaffold/src/views/w3m-account-view/index.ts
+++ b/packages/scaffold/src/views/w3m-account-view/index.ts
@@ -10,7 +10,8 @@ import {
   SnackController,
   ConnectorController,
   ConstantsUtil,
-  StorageUtil
+  StorageUtil,
+  AssetUtil
 } from '@web3modal/core'
 import { UiHelperUtil, customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
@@ -78,7 +79,7 @@ export class W3mAccountView extends LitElement {
       throw new Error('w3m-account-view: No account provided')
     }
 
-    const networkImage = this.networkImages[this.network?.imageId ?? '']
+    const networkImage = AssetUtil.getNetworkImage(this.network)
 
     return html`
       <wui-flex

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -22,10 +22,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
-  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
+import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import type { EIP6963Connector } from './connectors/EIP6963Connector.js'
 import type { EmailConnector } from './connectors/EmailConnector.js'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
@@ -36,7 +36,7 @@ import { WALLET_CHOICE_KEY } from './utils/constants.js'
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wagmiConfig: Config<any, any>
-  siweConfig?: SIWEControllerClient
+  siweConfig?: Web3ModalSIWEClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -22,10 +22,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
+  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
-import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import type { EIP6963Connector } from './connectors/EIP6963Connector.js'
 import type { EmailConnector } from './connectors/EmailConnector.js'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
@@ -36,7 +36,7 @@ import { WALLET_CHOICE_KEY } from './utils/constants.js'
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wagmiConfig: Config<any, any>
-  siweConfig?: Web3ModalSIWEClient
+  siweConfig?: SIWEControllerClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>


### PR DESCRIPTION
# Changes

We're accessing the network image SRC in different ways in different components. We can use custom chain images if we use `AssetUtil.getNetworkImage`. So instead of manually getting the network image, using `AssetUtil` will fix the issue linked below.

# Changes

- fix: custom network image rendering

# Test

Add a map to the `createWeb3Modal` function as parameter like the following:

```js
const modal = createWeb3Modal({
  ...
  chainImages: {
    1: 'image_url...'
  }
})
```


# Associated Issues

Closes https://github.com/WalletConnect/web3modal/issues/1406
Closes https://github.com/WalletConnect/web3modal/issues/1405
