### PR TITLE
fix: syncing profile info on network switch

### DIFF
--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -10,8 +10,8 @@ export interface AccountControllerState {
   address?: string
   balance?: string
   balanceSymbol?: string
-  profileName?: string
-  profileImage?: string
+  profileName?: string | null
+  profileImage?: string | null
   addressExplorerUrl?: string
 }
 

--- a/packages/core/src/utils/TypeUtil.ts
+++ b/packages/core/src/utils/TypeUtil.ts
@@ -125,8 +125,8 @@ export interface BlockchainApiIdentityRequest {
 }
 
 export interface BlockchainApiIdentityResponse {
-  avatar: string
-  name: string
+  avatar: string | null
+  name: string | null
 }
 
 export interface BlockchainApiTransactionsRequest {

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -777,6 +777,7 @@ export class Web3Modal extends Web3ModalScaffold {
             this.setAddressExplorerUrl(undefined)
           }
           if (this.hasSyncedConnectedAccount) {
+            await this.syncProfile(address)
             await this.syncBalance(address)
           }
         }
@@ -785,14 +786,22 @@ export class Web3Modal extends Web3ModalScaffold {
   }
 
   private async syncProfile(address: Address) {
-    const ensProvider = new InfuraProvider('mainnet')
-    const name = await ensProvider.lookupAddress(address)
-    const avatar = await ensProvider.getAvatar(address)
-    if (name) {
-      this.setProfileName(name)
-    }
-    if (avatar) {
-      this.setProfileImage(avatar)
+    const chainId = EthersStoreUtil.state.chainId
+
+    if (chainId === 1) {
+      const ensProvider = new InfuraProvider('mainnet')
+      const name = await ensProvider.lookupAddress(address)
+      const avatar = await ensProvider.getAvatar(address)
+
+      if (name) {
+        this.setProfileName(name)
+      }
+      if (avatar) {
+        this.setProfileImage(avatar)
+      }
+    } else {
+      this.setProfileName(null)
+      this.setProfileImage(null)
     }
   }
 

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -8,10 +8,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
-  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
+import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
 import EthereumProvider from '@walletconnect/ethereum-provider'
 import type {
@@ -33,7 +33,7 @@ import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider'
 // -- Types ---------------------------------------------------------------------
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   ethersConfig: ProviderType
-  siweConfig?: SIWEControllerClient
+  siweConfig?: Web3ModalSIWEClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -8,10 +8,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
+  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
-import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
 import EthereumProvider from '@walletconnect/ethereum-provider'
 import type {
@@ -33,7 +33,7 @@ import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider'
 // -- Types ---------------------------------------------------------------------
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   ethersConfig: ProviderType
-  siweConfig?: Web3ModalSIWEClient
+  siweConfig?: SIWEControllerClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -728,14 +728,22 @@ export class Web3Modal extends Web3ModalScaffold {
   }
 
   private async syncProfile(address: Address) {
-    const ensProvider = new ethers.providers.InfuraProvider('mainnet')
-    const name = await ensProvider.lookupAddress(address)
-    const avatar = await ensProvider.getAvatar(address)
-    if (name) {
-      this.setProfileName(name)
-    }
-    if (avatar) {
-      this.setProfileImage(avatar)
+    const chainId = EthersStoreUtil.state.chainId
+
+    if (chainId === 1) {
+      const ensProvider = new ethers.providers.InfuraProvider('mainnet')
+      const name = await ensProvider.lookupAddress(address)
+      const avatar = await ensProvider.getAvatar(address)
+
+      if (name) {
+        this.setProfileName(name)
+      }
+      if (avatar) {
+        this.setProfileImage(avatar)
+      }
+    } else {
+      this.setProfileName(null)
+      this.setProfileImage(null)
     }
   }
 

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -10,7 +10,8 @@ import {
   getNetwork,
   switchNetwork,
   watchAccount,
-  watchNetwork
+  watchNetwork,
+  mainnet
 } from '@wagmi/core'
 import type {
   CaipAddress,
@@ -308,6 +309,12 @@ export class Web3Modal extends Web3ModalScaffold {
   }
 
   private async syncProfile(address: Address, chain: Chain) {
+    if (chain.id !== mainnet.id) {
+      this.setProfileName(null)
+      this.setProfileImage(null)
+      return
+    }
+
     try {
       const { name, avatar } = await this.fetchIdentity({
         caipChainId: `${ConstantsUtil.EIP155}:${chain.id}`,

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -267,7 +267,7 @@ export class Web3Modal extends Web3ModalScaffold {
       this.setIsConnected(isConnected)
       this.setCaipAddress(caipAddress)
       await Promise.all([
-        this.syncProfile(address),
+        this.syncProfile(address, chain),
         this.syncBalance(address, chain),
         this.getApprovedCaipNetworksData()
       ])
@@ -301,25 +301,26 @@ export class Web3Modal extends Web3ModalScaffold {
           this.setAddressExplorerUrl(undefined)
         }
         if (this.hasSyncedConnectedAccount) {
+          await this.syncProfile(address, chain)
           await this.syncBalance(address, chain)
         }
       }
     }
   }
 
-  private async syncProfile(address: Address) {
+  private async syncProfile(address: Address, chain: Chain) {
     try {
       const { name, avatar } = await this.fetchIdentity({
-        caipChainId: `${ConstantsUtil.EIP155}:${mainnet.id}`,
+        caipChainId: `${ConstantsUtil.EIP155}:${chain.id}`,
         address
       })
       this.setProfileName(name)
       this.setProfileImage(avatar)
     } catch {
-      const profileName = await fetchEnsName({ address, chainId: mainnet.id })
+      const profileName = await fetchEnsName({ address, chainId: chain.id })
       if (profileName) {
         this.setProfileName(profileName)
-        const profileImage = await fetchEnsAvatar({ name: profileName, chainId: mainnet.id })
+        const profileImage = await fetchEnsAvatar({ name: profileName, chainId: chain.id })
         if (profileImage) {
           this.setProfileImage(profileImage)
         }

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -12,7 +12,6 @@ import {
   watchAccount,
   watchNetwork
 } from '@wagmi/core'
-import { mainnet } from '@wagmi/core/chains'
 import type {
   CaipAddress,
   CaipNetwork,
@@ -22,10 +21,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
+  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
-import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import type { EIP6963Connector } from './connectors/EIP6963Connector.js'
 import type { EmailConnector } from './connectors/EmailConnector.js'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
@@ -36,7 +35,7 @@ import { WALLET_CHOICE_KEY } from './utils/constants.js'
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wagmiConfig: Config<any, any>
-  siweConfig?: Web3ModalSIWEClient
+  siweConfig?: SIWEControllerClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -21,10 +21,10 @@ import type {
   LibraryOptions,
   NetworkControllerClient,
   PublicStateControllerState,
-  SIWEControllerClient,
   Token
 } from '@web3modal/scaffold'
 import { Web3ModalScaffold } from '@web3modal/scaffold'
+import type { Web3ModalSIWEClient } from '@web3modal/siwe'
 import type { EIP6963Connector } from './connectors/EIP6963Connector.js'
 import type { EmailConnector } from './connectors/EmailConnector.js'
 import { ConstantsUtil, PresetsUtil, HelpersUtil } from '@web3modal/scaffold-utils'
@@ -35,7 +35,7 @@ import { WALLET_CHOICE_KEY } from './utils/constants.js'
 export interface Web3ModalClientOptions extends Omit<LibraryOptions, 'defaultChain' | 'tokens'> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wagmiConfig: Config<any, any>
-  siweConfig?: SIWEControllerClient
+  siweConfig?: Web3ModalSIWEClient
   chains?: Chain[]
   defaultChain?: Chain
   chainImages?: Record<number, string>

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -312,6 +312,7 @@ export class Web3Modal extends Web3ModalScaffold {
     if (chain.id !== mainnet.id) {
       this.setProfileName(null)
       this.setProfileImage(null)
+
       return
     }
 


### PR DESCRIPTION
# Changes

When we switch network, we don't sync the profile information. This causes displayin ENS name or avatar in all networks, which is not expected. 

# Steps to reproduce

(Considering you have ENS name set to your account):
- Connect wallet to Ethereum Mainnet
- See ENS name
- Switch to Avalanche

You still see the ENS name. 

# Changes

- fix: sync profile on the network switch and consider not only mainnet

# Associated Issues

Closes https://github.com/WalletConnect/web3modal/issues/1407
Closes https://github.com/WalletConnect/web3modal/issues/1544
Closes https://github.com/WalletConnect/web3modal/issues/1519#issue-2018270402
