### PR TITLE
fix: all wallets shimmer bug

### DIFF
--- a/packages/scaffold/src/partials/w3m-all-wallets-list/index.ts
+++ b/packages/scaffold/src/partials/w3m-all-wallets-list/index.ts
@@ -114,6 +114,10 @@ export class W3mAllWalletsList extends LitElement {
     let shimmerCount = minimumRows * columns - currentWallets + columns
     shimmerCount -= wallets.length ? featured.length % columns : 0
 
+    if (count === 0 && featured.length > 0) {
+      return null
+    }
+
     if (count === 0 || [...featured, ...wallets, ...recommended].length < count) {
       return this.shimmerTemplate(shimmerCount, PAGINATOR_ID)
     }

--- a/packages/scaffold/src/views/w3m-connect-view/index.ts
+++ b/packages/scaffold/src/views/w3m-connect-view/index.ts
@@ -200,7 +200,11 @@ export class W3mConnectView extends LitElement {
       return null
     }
 
-    const roundedCount = Math.floor(ApiController.state.count / 10) * 10
+    const count = ApiController.state.count
+    const featuredCount = ApiController.state.featured?.length
+    const rawCount = count + featuredCount
+    const roundedCount = rawCount < 10 ? rawCount : Math.floor(rawCount / 10) * 10
+    const tagLabel = roundedCount < rawCount ? `${roundedCount}+` : `${roundedCount}`
 
     return html`
       <wui-list-wallet
@@ -208,7 +212,7 @@ export class W3mConnectView extends LitElement {
         walletIcon="allWallets"
         showAllWallets
         @click=${this.onAllWallets.bind(this)}
-        tagLabel=${`${roundedCount}+`}
+        tagLabel=${`${tagLabel}`}
         tagVariant="shade"
       ></wui-list-wallet>
     `

--- a/packages/scaffold/src/views/w3m-connect-view/index.ts
+++ b/packages/scaffold/src/views/w3m-connect-view/index.ts
@@ -201,7 +201,7 @@ export class W3mConnectView extends LitElement {
     }
 
     const count = ApiController.state.count
-    const featuredCount = ApiController.state.featured?.length
+    const featuredCount = ApiController.state.featured.length
     const rawCount = count + featuredCount
     const roundedCount = rawCount < 10 ? rawCount : Math.floor(rawCount / 10) * 10
     const tagLabel = roundedCount < rawCount ? `${roundedCount}+` : `${roundedCount}`
@@ -212,7 +212,7 @@ export class W3mConnectView extends LitElement {
         walletIcon="allWallets"
         showAllWallets
         @click=${this.onAllWallets.bind(this)}
-        tagLabel=${`${tagLabel}`}
+        tagLabel=${tagLabel}
         tagVariant="shade"
       ></wui-list-wallet>
     `


### PR DESCRIPTION
# Changes

When we set `includeWalletIds` and `featuredWalledIds` as the same array, in case people want to show only a few wallets in the wallet select page, the all wallets button and the all wallets page have a few issues:

- All wallets button shows a wrong number of wallet options on the right side. This is fixed in https://github.com/WalletConnect/web3modal/pull/1499/files but we should consider featured apps for the whole count too.
- All wallet lists should be considered if there are only featured apps. When we calculate the `count` value in `ApiController`, the `featured` wallets are not counted, but we fetch the featured ones in all wallet lists 


# Steps to reproduce

- In the `createWeb3Modal` function, pass the `includeWalletIds` and pass `featuredWalletIds` as the same array of Wallet id's.

# Test

- [x] Wagmi examples (default, siwe, email)
- [x] Ethers examples (default, siwe, email)

# Changes

- fix: all wallets count calculation
- fix: all wallet list shimmer rendering logic when only have featured items

# Associated Issues

Closes https://github.com/WalletConnect/web3modal/issues/1566
