### PR TITLE
fix: use prop binding for images in transaction item components

### DIFF
--- a/packages/scaffold/src/views/w3m-transactions-view/index.ts
+++ b/packages/scaffold/src/views/w3m-transactions-view/index.ts
@@ -134,7 +134,7 @@ export class W3mTransactionsView extends LitElement {
           id=${isLastTransaction && this.next ? PAGINATOR_ID : ''}
           status=${status}
           type=${type}
-          images=${images}
+          .images=${images}
           .descriptions=${descriptions}
         ></wui-transaction-list-item>
       `
@@ -152,7 +152,7 @@ export class W3mTransactionsView extends LitElement {
           status=${status}
           type=${type}
           .onlyDirectionIcon=${true}
-          images=${[images?.[index]]}
+          .images=${[images?.[index]]}
           .descriptions=${[description]}
         ></wui-transaction-list-item>`
       })


### PR DESCRIPTION
# Changes

With the recent changes, we removed the prop binding prefix from the `images` prop of the transaction items. This breaks the props and causes an error. Since the images are an array of string, we should use `dot` prefix.

# Changes

- fix: images prop binding for `wui-transaction-list-item`
