### PR TITLE
refactor: update copy link rendering condition

### DIFF
--- a/packages/scaffold/src/partials/w3m-connecting-wc-qrcode/index.ts
+++ b/packages/scaffold/src/partials/w3m-connecting-wc-qrcode/index.ts
@@ -71,11 +71,9 @@ export class W3mConnectingWcQrcode extends W3mConnectingWidget {
   }
 
   private copyTemplate() {
-    if (!this.uri || !this.ready) {
-      return null
-    }
+    const inactive = !this.uri || !this.ready
 
-    return html`<wui-link @click=${this.onCopyUri} color="fg-200">
+    return html`<wui-link .disabled=${inactive} @click=${this.onCopyUri} color="fg-200">
       <wui-icon size="xs" color="fg-200" slot="iconLeft" name="copy"></wui-icon>
       Copy link
     </wui-link>`


### PR DESCRIPTION
# Changes

We're currently rendering the copy link button conditionally depending on the `uri` and `ready` states. This causes a layout shift when we get these values updated. Instead of hiding the copy button, we could disable it so it'll be available at the same the the QR code is loaded
 
N/A

# Changes

- fix: copy button causes layout shift on QR code loaded

# Associated Issues

https://walletconnect.slack.com/archives/C03RVH94K5K/p1703056394669249?thread_ts=1702956728.455579&cid=C03RVH94K5K