### PR TITLE
chore: update siwe version in optional deps list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27182,7 +27182,7 @@
         "ethers": "5.7.2"
       },
       "optionalDependencies": {
-        "@web3modal/siwe": "3.5.0-6a05dc24",
+        "@web3modal/siwe": "*",
         "react": ">=17",
         "react-dom": ">=17",
         "vue": ">=3"

--- a/packages/ethers5/package.json
+++ b/packages/ethers5/package.json
@@ -78,7 +78,7 @@
     }
   },
   "optionalDependencies": {
-    "@web3modal/siwe": "3.5.0-6a05dc24",
+    "@web3modal/siwe": "*",
     "react": ">=17",
     "react-dom": ">=17",
     "vue": ">=3"


### PR DESCRIPTION
# Breaking Changes

In the `ethers5` package, we're using the old version of `siwe` package which is not automatically updated via Lerna CLI. Instead using asterix `*` to get the latest version in Monorepo should fix it.

# Changes

- fix: update `siwe` version in ethers5 package

# Associated Issues

closes https://github.com/WalletConnect/web3modal/issues/1650
closes https://github.com/WalletConnect/web3modal/issues/1653
