### PR TITLE
fix: account button hide balance on small device views

### DIFF
--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -76,7 +76,7 @@ export default css`
 
   @media (max-width: 450px) {
     button {
-      gap: 0;
+      gap: 0px;
     }
     wui-image,
     wui-icon-box,

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -74,7 +74,7 @@ export default css`
     box-shadow: 0 0 0 2px var(--wui-accent-glass-010);
   }
 
-  @media (max-width: 450px) {
+  @media (max-width: 500px) {
     button {
       gap: 0px;
     }

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -83,6 +83,7 @@ export default css`
     button > wui-text {
       visibility: hidden;
       width: 0px;
+      height: 0px;
     }
     button > wui-flex {
       border-radius: 0px;

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -74,6 +74,23 @@ export default css`
     box-shadow: 0 0 0 2px var(--wui-accent-glass-010);
   }
 
+  @media (max-width: 450px) {
+    button {
+      gap: 0;
+    }
+    wui-image,
+    wui-icon-box,
+    button > wui-text {
+      visibility: hidden;
+      width: 0px;
+    }
+    button > wui-flex {
+      border-radius: 0px;
+      border: none;
+      background: transparent;
+    }
+  }
+
   @media (hover: hover) and (pointer: fine) {
     button:hover:enabled > wui-flex > wui-text {
       color: var(--wui-color-fg-175);


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: wui-account-button responsive styles. Removed balance on small screens.
- chore:

# Associated Issues
https://github.com/WalletConnect/web3modal/issues/1668
