### PR TITLE
Fix/account button responsive 2

### DIFF
--- a/apps/gallery/stories/composites/wui-account-button.stories.ts
+++ b/apps/gallery/stories/composites/wui-account-button.stories.ts
@@ -14,7 +14,9 @@ export default {
     avatarSrc: avatarImageSrc,
     address,
     balance: '0.527 ETH',
-    isProfileName: false
+    isProfileName: false,
+    charsStart: 4,
+    charsEnd: 6
   },
   argTypes: {
     disabled: {
@@ -35,5 +37,7 @@ export const Default: Component = {
       .avatarSrc=${args.avatarSrc}
       .balance=${args.balance}
       address=${args.address}
+      .charsStart=${args.charsStart}
+      .charsEnd=${args.charsEnd}
     ></wui-account-button>`
 }

--- a/packages/scaffold/src/modal/w3m-account-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-account-button/index.ts
@@ -21,6 +21,10 @@ export class W3mAccountButton extends LitElement {
 
   @property() public balance?: 'show' | 'hide' = 'show'
 
+  @property() public charsStart?: WuiAccountButton['charsStart'] = 4
+
+  @property() public charsEnd?: WuiAccountButton['charsEnd'] = 6
+
   @state() private address = AccountController.state.address
 
   @state() private balanceVal = AccountController.state.balance
@@ -79,6 +83,8 @@ export class W3mAccountButton extends LitElement {
           : ''}
         @click=${this.onClick.bind(this)}
         data-testid="account-button"
+        .charsStart=${this.charsStart}
+        .charsEnd=${this.charsEnd}
       >
       </wui-account-button>
     `

--- a/packages/scaffold/src/modal/w3m-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-button/index.ts
@@ -22,6 +22,10 @@ export class W3mButton extends LitElement {
 
   @property() public loadingLabel?: W3mConnectButton['loadingLabel'] = undefined
 
+  @property() public charsStart?: W3mAccountButton['charsStart'] = 4
+
+  @property() public charsEnd?: W3mAccountButton['charsEnd'] = 6
+
   @state() private isAccount = AccountController.state.isConnected
 
   // -- Lifecycle ----------------------------------------- //
@@ -45,6 +49,8 @@ export class W3mButton extends LitElement {
           <w3m-account-button
             .disabled=${Boolean(this.disabled)}
             balance=${ifDefined(this.balance)}
+            charsStart=${ifDefined(this.charsStart)}
+            charsEnd=${ifDefined(this.charsEnd)}
           >
           </w3m-account-button>
         `

--- a/packages/scaffold/src/modal/w3m-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-button/index.ts
@@ -49,8 +49,8 @@ export class W3mButton extends LitElement {
           <w3m-account-button
             .disabled=${Boolean(this.disabled)}
             balance=${ifDefined(this.balance)}
-            charsStart=${ifDefined(this.charsStart)}
-            charsEnd=${ifDefined(this.charsEnd)}
+            .charsStart=${ifDefined(this.charsStart)}
+            .charsEnd=${ifDefined(this.charsEnd)}
           >
           </w3m-account-button>
         `

--- a/packages/ui/src/composites/wui-account-button/index.ts
+++ b/packages/ui/src/composites/wui-account-button/index.ts
@@ -28,6 +28,10 @@ export class WuiAccountButton extends LitElement {
 
   @property() public address = ''
 
+  @property() public charsStart = 4
+
+  @property() public charsEnd = 6
+
   // -- Render -------------------------------------------- //
   public override render() {
     return html`
@@ -45,8 +49,8 @@ export class WuiAccountButton extends LitElement {
           <wui-text variant="paragraph-600" color="inherit">
             ${UiHelperUtil.getTruncateString({
               string: this.address,
-              charsStart: this.isProfileName ? 18 : 4,
-              charsEnd: this.isProfileName ? 0 : 6,
+              charsStart: this.isProfileName ? 18 : this.charsStart,
+              charsEnd: this.isProfileName ? 0 : this.charsEnd,
               truncate: this.isProfileName ? 'end' : 'middle'
             })}
           </wui-text>

--- a/packages/ui/src/composites/wui-account-button/index.ts
+++ b/packages/ui/src/composites/wui-account-button/index.ts
@@ -31,13 +31,12 @@ export class WuiAccountButton extends LitElement {
   // -- Render -------------------------------------------- //
   public override render() {
     return html`
-      <button ?disabled=${this.disabled}>
+      <button
+        ?disabled=${this.disabled}
+        class=${ifDefined(this.balance ? undefined : 'local-no-balance')}
+      >
         ${this.balanceTemplate()}
-        <wui-flex
-          gap="xxs"
-          alignItems="center"
-          class=${ifDefined(this.balance ? undefined : 'local-no-balance')}
-        >
+        <wui-flex gap="xxs" alignItems="center">
           <wui-avatar
             .imageSrc=${this.avatarSrc}
             alt=${this.address}

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -77,6 +77,7 @@ export default css`
   @media (max-width: 500px) {
     button {
       gap: 0px;
+      padding: var(--wui-spacing-3xs) var(--wui-spacing-xs) !important;
     }
     wui-image,
     wui-icon-box,
@@ -89,6 +90,7 @@ export default css`
       border-radius: 0px;
       border: none;
       background: transparent;
+      padding: 0px;
     }
   }
 

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -62,7 +62,7 @@ export default css`
     padding: 4px var(--wui-spacing-m) 4px var(--wui-spacing-xxs);
   }
 
-  wui-flex.local-no-balance {
+  button.local-no-balance {
     border-radius: 0px;
     border: none;
     background: transparent;
@@ -86,7 +86,7 @@ export default css`
       width: 0px;
       height: 0px;
     }
-    button > wui-flex {
+    button {
       border-radius: 0px;
       border: none;
       background: transparent;


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat: add `charsStart` and  `charsEnd` properties to `wui-account-button`
- fix: responsive styling for `wui-account-button`
- chore:

## Screenshots


https://github.com/WalletConnect/web3modal/assets/12738697/bdb4a329-abe2-4d33-9428-7696b5f2a329


