### PR TITLE
chore(ui-test): extend more time for tests

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -23,7 +23,7 @@ jobs:
   ui_tests:
     name: 'Playwright Tests'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The work to parallelize the tests to make them faster is currently [blocked](https://github.com/WalletConnect/web3modal/pull/1682).

# Breaking Changes

N/A

# Changes

- feat:
- fix:
- chore:

# Associated Issues

closes #...
