### PR TITLE
fix: ethers send transaction

### DIFF
--- a/apps/laboratory/src/components/Ethers/EthersTransactionButton.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersTransactionButton.tsx
@@ -17,9 +17,8 @@ export function EthersTransactionButton() {
       const signer = new JsonRpcSigner(provider, address)
       const tx = await signer.sendTransaction({
         to: vitalikEthAddress,
-        value: ethers.parseUnits('0.1', 'gwei')
+        value: ethers.parseUnits('0.001', 'gwei')
       })
-
       toast({ title: 'Succcess', description: tx.blockHash, status: 'success', isClosable: true })
     } catch {
       toast({

--- a/packages/wallet/src/W3mFrameSchema.ts
+++ b/packages/wallet/src/W3mFrameSchema.ts
@@ -56,6 +56,14 @@ export const RpcEthSignTypedDataV4 = z.object({
   method: z.literal('eth_signTypedData_v4'),
   params: z.array(z.any())
 })
+export const RpcEthBlockNumber = z.object({
+  method: z.literal('eth_blockNumber')
+})
+
+export const RpcEthChainId = z.object({
+  method: z.literal('eth_chainId')
+})
+
 export const FrameSession = z.object({
   token: z.string()
 })
@@ -89,6 +97,8 @@ export const W3mFrameSchema = {
           .or(RpcEthEstimateGas)
           .or(RpcEthGasPrice)
           .or(RpcEthSignTypedDataV4)
+          .or(RpcEthBlockNumber)
+          .or(RpcEthChainId)
       })
     )
 

--- a/packages/wallet/src/W3mFrameTypes.ts
+++ b/packages/wallet/src/W3mFrameTypes.ts
@@ -16,11 +16,13 @@ import {
   RpcEthEstimateGas,
   RpcEthGasPrice,
   RpcGetBalance,
+  RpcEthBlockNumber,
   FrameSession,
   AppGetUserRequest,
   AppUpdateEmailRequest,
   FrameAwaitUpdateEmailResponse,
-  AppSyncThemeRequest
+  AppSyncThemeRequest,
+  RpcEthChainId
 } from './W3mFrameSchema.js'
 
 export namespace W3mFrameTypes {
@@ -58,6 +60,8 @@ export namespace W3mFrameTypes {
     | z.infer<typeof RpcEthEstimateGas>
     | z.infer<typeof RpcEthGasPrice>
     | z.infer<typeof RpcGetBalance>
+    | z.infer<typeof RpcEthBlockNumber>
+    | z.infer<typeof RpcEthChainId>
 
   export type RPCResponse = z.infer<typeof RpcResponse>
 


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: adds eth_chainId and eth_blockNumber to possible RPC call tpyes in zod, to prevent errors when ethers does intermediate rpc calls.
- chore:

# Notes
- Have been able to sort out zod errors on lab side with this, but secure site needs this to be deployed in order to work. 
