### PR TITLE
feat(ui-test): cover webkit

### DIFF
--- a/apps/laboratory/playwright.config.ts
+++ b/apps/laboratory/playwright.config.ts
@@ -48,6 +48,16 @@ export default defineConfig<ModalFixture>({
     {
       name: 'firefox/ethers',
       use: { ...devices['Desktop Firefox'], library: 'ethers' }
+    },
+
+    {
+      name: 'webkit/ethers',
+      use: { ...devices['Desktop Safari'], library: 'ethers' }
+    },
+
+    {
+      name: 'webkit/ethers',
+      use: { ...devices['Desktop Safari'], library: 'ethers' }
     }
   ],
 

--- a/apps/laboratory/tests/connect.spec.ts
+++ b/apps/laboratory/tests/connect.spec.ts
@@ -1,30 +1,54 @@
 import { DEFAULT_SESSION_PARAMS } from './shared/constants'
 import { testMW } from './shared/fixtures/w3m-wallet-fixture'
 
-testMW.beforeEach(async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
-  await modalPage.copyConnectUriToClipboard()
-  await walletPage.connect()
-  await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
-  await modalValidator.expectConnected()
-  await walletValidator.expectConnected()
-})
+testMW.beforeEach(
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    console.log('browserName', browserName)
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      return
+    }
+    await modalPage.copyConnectUriToClipboard()
+    await walletPage.connect()
+    await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
+    await modalValidator.expectConnected()
+    await walletValidator.expectConnected()
+  }
+)
 
-testMW.afterEach(async ({ modalPage, modalValidator, walletValidator }) => {
+testMW.afterEach(async ({ modalPage, modalValidator, walletValidator, browserName }) => {
+  // Webkit cannot use clipboard.
+  if (browserName === 'webkit') {
+    return
+  }
   await modalPage.disconnect()
   await modalValidator.expectDisconnected()
   await walletValidator.expectDisconnected()
 })
 
-testMW('it should sign', async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
-  await modalPage.sign()
-  await walletValidator.expectReceivedSign({})
-  await walletPage.handleRequest({ accept: true })
-  await modalValidator.expectAcceptedSign()
-})
+testMW(
+  'it should sign',
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      testMW.skip()
+      return
+    }
+    await modalPage.sign()
+    await walletValidator.expectReceivedSign({})
+    await walletPage.handleRequest({ accept: true })
+    await modalValidator.expectAcceptedSign()
+  }
+)
 
 testMW(
   'it should reject sign',
-  async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      testMW.skip()
+      return
+    }
     await modalPage.sign()
     await walletValidator.expectReceivedSign({})
     await walletPage.handleRequest({ accept: false })
@@ -34,7 +58,12 @@ testMW(
 
 testMW(
   'it should switch networks and sign',
-  async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      testMW.skip()
+      return
+    }
     let targetChain = 'Polygon'
     await modalPage.switchNetwork(targetChain)
     await modalPage.sign()

--- a/apps/laboratory/tests/siwe.spec.ts
+++ b/apps/laboratory/tests/siwe.spec.ts
@@ -1,20 +1,33 @@
 import { DEFAULT_SESSION_PARAMS } from './shared/constants'
 import { testMWSiwe } from './shared/fixtures/w3m-wallet-fixture'
 
-testMWSiwe.beforeEach(async ({ modalPage, walletPage }) => {
+testMWSiwe.beforeEach(async ({ modalPage, walletPage, browserName }) => {
+  // Webkit cannot use clipboard.
+  if (browserName === 'webkit') {
+    return
+  }
   await modalPage.copyConnectUriToClipboard()
   await walletPage.connect()
   await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
 })
 
-testMWSiwe.afterEach(async ({ modalValidator, walletValidator }) => {
+testMWSiwe.afterEach(async ({ modalValidator, walletValidator, browserName }) => {
+  // Webkit cannot use clipboard.
+  if (browserName === 'webkit') {
+    return
+  }
   await modalValidator.expectDisconnected()
   await walletValidator.expectDisconnected()
 })
 
 testMWSiwe(
   'it should sign in with ethereum',
-  async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      testMWSiwe.skip()
+      return
+    }
     await modalPage.promptSiwe()
     await walletValidator.expectReceivedSign({})
     await walletPage.handleRequest({ accept: true })
@@ -27,7 +40,12 @@ testMWSiwe(
 
 testMWSiwe(
   'it should reject sign in with ethereum',
-  async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+  async ({ modalPage, walletPage, modalValidator, walletValidator, browserName }) => {
+    // Webkit cannot use clipboard.
+    if (browserName === 'webkit') {
+      testMWSiwe.skip()
+      return
+    }
     await modalPage.promptSiwe()
     await walletValidator.expectReceivedSign({})
     await walletPage.handleRequest({ accept: false })


### PR DESCRIPTION
Basic and Email tests can use webkit (doesn't use Clipboard). Other tests still blocked on removing clipboard. That is unblocked yesterday CC @ganchoradkov 

# Breaking Changes

N/A

# Changes

- feat(ui-test): cover webkit
- fix:
- chore:

# Associated Issues

closes #...
