### PR TITLE
fix: activity image tearing

### DIFF
--- a/packages/ui/src/composites/wui-transaction-visual/styles.ts
+++ b/packages/ui/src/composites/wui-transaction-visual/styles.ts
@@ -14,7 +14,6 @@ export default css`
 
   :host > wui-flex wui-image {
     display: block;
-    z-index: -1;
   }
 
   :host > wui-flex,


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: images tearing on activity when scrolling the view.
- chore:


## Note
- This was only happening on windows, would need a windows user to test this
