### PR TITLE
fix balance

### DIFF
--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -317,14 +317,17 @@ export class Web3Modal extends Web3ModalScaffold {
 
   private async syncBalance(address: Hex, chainId: number) {
     const chain = this.wagmiConfig.chains.find((c: Chain) => c.id === chainId)
+    if (chain) {
+      const balance = await getBalance(this.wagmiConfig, {
+        address,
+        chainId: chain.id,
+        token: this.options?.tokens?.[chain.id]?.address as Hex
+      })
+      this.setBalance(balance.formatted, balance.symbol)
 
-    const id = chain?.id || this.options?.defaultChain?.id || this.wagmiConfig?.chains?.[0]?.id
-    const balance = await getBalance(this.wagmiConfig, {
-      address,
-      chainId: id,
-      token: this.options?.tokens?.[id]?.address as Hex
-    })
-    this.setBalance(balance.formatted, balance.symbol)
+      return
+    }
+    this.setBalance(undefined, undefined)
   }
 
   private syncConnectors(


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- fix: If the chain wasn't in config we were fetching the balance of the defaultChain or the first configured chain which is inacurated data from the current connected chain, this PR will skip the fetch of the balance and set it directly to `0.000` if the chain is not registered. 

Notice:

- We cannot fetch the balance of an unregistered chain because Wagmi function will throw an error + we don't have the symbol info to display in the UI
- We should have a UI view to show the user is on an incorrected chain

# Associated Issues

closes https://github.com/WalletConnect/web3modal/issues/1836
