### PR TITLE
fix: set caipAddress to caipAddress

### DIFF
--- a/packages/scaffold/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold/src/modal/w3m-modal/index.ts
@@ -30,7 +30,7 @@ export class W3mModal extends LitElement {
   // -- State & Properties -------------------------------- //
   @state() private open = ModalController.state.open
 
-  @state() private caipAddress = AccountController.state.address
+  @state() private caipAddress = AccountController.state.caipAddress
 
   @state() private isSiweEnabled = SIWEController.state.isSiweEnabled
 


### PR DESCRIPTION
For some reason you have used vanilla address when CAIP one was expected. This breaks SIWE flow.

When `isConnected && newCaipAddress && this.caipAddress !== newCaipAddress` condition is checked on https://github.com/WalletConnect/web3modal/blob/V4/packages/scaffold/src/modal/w3m-modal/index.ts#L170, obviously it fails, leading to re-sign-in using SIWE.