### PR TITLE
fix: cache might restore the wrong files

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-${{ hashFiles('apps/laboratory/tests/shared/constants/devices.ts') }}
       - name: install
         run: npm ci
       - name: build

--- a/apps/laboratory/playwright.config.ts
+++ b/apps/laboratory/playwright.config.ts
@@ -3,7 +3,11 @@ import { BASE_URL } from './tests/shared/constants'
 
 import { config } from 'dotenv'
 import type { ModalFixture } from './tests/shared/fixtures/w3m-fixture'
+import { DEVICES } from './tests/shared/constants/devices'
 config({ path: './.env' })
+
+const LIBRARIES = ['wagmi', 'ethers'] as const
+const PERMUTATIONS = DEVICES.flatMap((device) => LIBRARIES.map((library) => ({ device, library })))
 
 export default defineConfig<ModalFixture>({
   testDir: './tests',
@@ -29,37 +33,10 @@ export default defineConfig<ModalFixture>({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium/wagmi',
-      use: { ...devices['Desktop Chrome'], library: 'wagmi' }
-    },
-
-    {
-      name: 'firefox/wagmi',
-      use: { ...devices['Desktop Firefox'], library: 'wagmi' }
-    },
-
-    {
-      name: 'chromium/ethers',
-      use: { ...devices['Desktop Chrome'], library: 'ethers' }
-    },
-
-    {
-      name: 'firefox/ethers',
-      use: { ...devices['Desktop Firefox'], library: 'ethers' }
-    },
-
-    {
-      name: 'webkit/ethers',
-      use: { ...devices['Desktop Safari'], library: 'ethers' }
-    },
-
-    {
-      name: 'webkit/ethers',
-      use: { ...devices['Desktop Safari'], library: 'ethers' }
-    }
-  ],
+  projects: PERMUTATIONS.map(({ device, library }) => ({
+    name: `${device}/${library}`,
+    use: { ...devices[device], library }
+  })),
 
   /* Run your local dev server before starting the tests */
   webServer: {

--- a/apps/laboratory/playwright.config.ts
+++ b/apps/laboratory/playwright.config.ts
@@ -7,7 +7,7 @@ import { DEVICES } from './tests/shared/constants/devices'
 config({ path: './.env' })
 
 const LIBRARIES = ['wagmi', 'ethers'] as const
-const PERMUTATIONS = DEVICES.flatMap((device) => LIBRARIES.map((library) => ({ device, library })))
+const PERMUTATIONS = DEVICES.flatMap(device => LIBRARIES.map(library => ({ device, library })))
 
 export default defineConfig<ModalFixture>({
   testDir: './tests',

--- a/apps/laboratory/tests/shared/constants/devices.ts
+++ b/apps/laboratory/tests/shared/constants/devices.ts
@@ -1,0 +1,1 @@
+export const DEVICES = ['Desktop Chrome', 'Desktop Firefox', 'Desktop Safari']


### PR DESCRIPTION
We've seend often tests downloading obsolte caches. 

# Breaking Changes

N/A

# Changes

[- fix:](fix: cache might restore the wrong files)

# Associated Issues

closes #...
