### PR TITLE
fix(verify): passing wrong domain for Verify

### DIFF
--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -10,7 +10,7 @@ export const ConstantsUtil = {
   Metadata: {
     name: 'Web3Modal',
     description: 'Web3Modal Laboratory',
-    url: 'https://web3modal.com',
+    url: 'https://lab.web3modal.com',
     icons: ['https://avatars.githubusercontent.com/u/37784886'],
     verifyUrl: ''
   },


### PR DESCRIPTION
# Testing

You can see that now `lab.web3modal.com` is passed in the metadata.

<img width="430" alt="Screenshot 2024-02-09 at 5 40 54 AM" src="https://github.com/WalletConnect/web3modal/assets/966091/3b7a3037-b427-4b76-b65c-adb819d80fb2">


# Associated Issues

closes #...
