### PR TITLE
fix: infinite loader when user is not connected

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -762,6 +762,10 @@ export class Web3Modal extends Web3ModalScaffold {
       this.emailProvider.onRpcResponse(() => {
         super.close()
       })
+      this.emailProvider.onNotConnected(() => {
+        this.setIsConnected(false)
+        super.setLoading(false)
+      })
       this.emailProvider.onIsConnected(() => {
         super.setLoading(false)
       })

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -387,6 +387,7 @@ export class Web3Modal extends Web3ModalScaffold {
 
       const provider = (await connector.getProvider()) as W3mFrameProvider
       const isLoginEmailUsed = provider.getLoginEmailUsed()
+
       super.setLoading(isLoginEmailUsed)
       if (isLoginEmailUsed) {
         this.setIsConnected(false)
@@ -397,9 +398,16 @@ export class Web3Modal extends Web3ModalScaffold {
           super.open({ view: 'ApproveTransaction' })
         }
       })
+
       provider.onRpcResponse(() => {
         super.close()
       })
+
+      provider.onNotConnected(() => {
+        this.setIsConnected(false)
+        super.setLoading(false)
+      })
+
       provider.onIsConnected(() => {
         this.setIsConnected(true)
         super.setLoading(false)

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -318,6 +318,20 @@ export class W3mFrameProvider {
     })
   }
 
+  public onNotConnected(callback: () => void) {
+    this.w3mFrame.events.onFrameEvent(event => {
+      if (event.type === W3mFrameConstants.FRAME_IS_CONNECTED_ERROR) {
+        callback()
+      }
+      if (
+        event.type === W3mFrameConstants.FRAME_IS_CONNECTED_SUCCESS &&
+        !event.payload.isConnected
+      ) {
+        callback()
+      }
+    })
+  }
+
   // -- Promise Handlers ------------------------------------------------
   private onConnectEmailSuccess(
     event: Extract<W3mFrameTypes.FrameEvent, { type: '@w3m-frame/CONNECT_EMAIL_SUCCESS' }>


### PR DESCRIPTION
When we receive `FRAME_IS_CONNECTED_SUCCESS` with value isConnected set to `false` instead of `true`, we are stuck in infinite loading state