### PR TITLE
feat: smart account creation

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -599,6 +599,7 @@ export class Web3Modal extends Web3ModalScaffold {
     const { smartAccountEnabledNetworks } =
       await this.emailProvider.getSmartAccountEnabledNetworks()
 
+    this.emailProvider.setSmartAccountEnabled(true)
     if (!smartAccountEnabledNetworks.includes(chainId)) {
       return { isDeployed: false }
     }

--- a/packages/scaffold/src/views/w3m-email-verify-otp-view/index.ts
+++ b/packages/scaffold/src/views/w3m-email-verify-otp-view/index.ts
@@ -1,12 +1,37 @@
 import { customElement } from '@web3modal/ui'
 import { W3mEmailOtpWidget } from '../../utils/w3m-email-otp-widget/index.js'
 import type { OnOtpSubmitFn, OnOtpResendFn } from '../../utils/w3m-email-otp-widget/index.js'
-import { EventsController, ConnectionController, ModalController } from '@web3modal/core'
+import {
+  EventsController,
+  ConnectionController,
+  ModalController,
+  NetworkController,
+  RouterController,
+  AccountController
+} from '@web3modal/core'
+import { state } from 'lit/decorators.js'
+import { W3mFrameHelpers } from '@web3modal/wallet'
 
 @customElement('w3m-email-verify-otp-view')
 export class W3mEmailVerifyOtpView extends W3mEmailOtpWidget {
+  // -- Members ------------------------------------------- //
+  private unsubscribe: (() => void)[] = []
+
+  // -- State ------------------------------------------- //
+  @state() private network = NetworkController.state.caipNetwork
+  @state() private smartAccountDeployed = AccountController.state.smartAccountDeployed
+
   public constructor() {
     super()
+
+    this.unsubscribe.push(
+      NetworkController.subscribeKey('caipNetwork', val => {
+        this.network = val
+      }),
+      AccountController.subscribeKey('smartAccountDeployed', val => {
+        this.smartAccountDeployed = val
+      })
+    )
   }
 
   // --  Private ------------------------------------------ //
@@ -16,12 +41,18 @@ export class W3mEmailVerifyOtpView extends W3mEmailOtpWidget {
         await this.emailConnector.provider.connectOtp({ otp })
         EventsController.sendEvent({ type: 'track', event: 'EMAIL_VERIFICATION_CODE_PASS' })
         await ConnectionController.connectExternal(this.emailConnector)
-        ModalController.close()
         EventsController.sendEvent({
           type: 'track',
           event: 'CONNECT_SUCCESS',
           properties: { method: 'email', name: this.emailConnector.name || 'Unknown' }
         })
+
+        const networkId = this.network?.id?.split(':')?.[1]
+        if (W3mFrameHelpers.checkIfSmartAccountEnabled(networkId) && !this.smartAccountDeployed) {
+          RouterController.push('UpgradeToSmartAccount')
+        } else {
+          ModalController.close()
+        }
       }
     } catch (error) {
       EventsController.sendEvent({ type: 'track', event: 'EMAIL_VERIFICATION_CODE_FAIL' })

--- a/packages/scaffold/src/views/w3m-upgrade-to-smart-account-view/index.ts
+++ b/packages/scaffold/src/views/w3m-upgrade-to-smart-account-view/index.ts
@@ -49,7 +49,12 @@ export class W3mUpgradeToSmartAccountView extends LitElement {
 
   private buttonsTemplate() {
     return html`<wui-flex .padding=${['0', '2l', '0', '2l'] as const} gap="s">
-      <wui-button variant="accentBg" @click=${RouterController.goBack} size="lg" borderRadius="xs">
+      <wui-button
+        variant="accentBg"
+        @click=${() => RouterController.push('Account')}
+        size="lg"
+        borderRadius="xs"
+      >
         Do it later
       </wui-button>
       <wui-button size="lg" borderRadius="xs"> Continue </wui-button>

--- a/packages/wagmi/src/connectors/EmailConnector.ts
+++ b/packages/wagmi/src/connectors/EmailConnector.ts
@@ -65,6 +65,7 @@ export function emailConnector(parameters: EmailParameters) {
       }
       const provider = await this.getProvider()
       const chainId = await this.getChainId()
+      provider.setSmartAccountEnabled(true)
       const { smartAccountEnabledNetworks } = await provider.getSmartAccountEnabledNetworks()
       if (smartAccountEnabledNetworks.includes(chainId)) {
         return (await provider.initSmartAccount()) as { isDeployed: boolean; address?: Address }

--- a/packages/wallet/src/W3mFrameConstants.ts
+++ b/packages/wallet/src/W3mFrameConstants.ts
@@ -1,5 +1,5 @@
 export const W3mFrameConstants = {
-  SECURE_SITE_SDK: 'https://secure.walletconnect.com/sdk',
+  SECURE_SITE_SDK: 'http://localhost:3010/sdk',
   APP_EVENT_KEY: '@w3m-app/',
   FRAME_EVENT_KEY: '@w3m-frame/',
   RPC_METHOD_KEY: 'RPC_',
@@ -11,6 +11,8 @@ export const W3mFrameConstants = {
   LAST_EMAIL_LOGIN_TIME: 'LAST_EMAIL_LOGIN_TIME',
   EMAIL: 'EMAIL',
   PREFERRED_ACCOUNT_TYPE: 'PREFERRED_ACCOUNT_TYPE',
+  SMART_ACCOUNT_ENABLED: 'SMART_ACCOUNT_ENABLED',
+  SMART_ACCOUNT_ENABLED_NETWORKS: 'SMART_ACCOUNT_ENABLED_NETWORKS',
 
   APP_SWITCH_NETWORK: '@w3m-app/SWITCH_NETWORK',
   APP_CONNECT_EMAIL: '@w3m-app/CONNECT_EMAIL',

--- a/packages/wallet/src/W3mFrameHelpers.ts
+++ b/packages/wallet/src/W3mFrameHelpers.ts
@@ -67,10 +67,24 @@ export const W3mFrameHelpers = {
     return (request as { payload: W3mFrameTypes.RPCRequest })?.payload?.method
   },
 
+  getSmartAccountEnabledNetworks() {
+    return W3mFrameStorage.get(W3mFrameConstants.SMART_ACCOUNT_ENABLED_NETWORKS)?.split(',') || []
+  },
+
   checkIfRequestIsAllowed(request: unknown) {
     const method = this.getRequestMethod(request)
 
     return W3mFrameRpcConstants.SAFE_RPC_METHODS.includes(method)
+  },
+
+  checkIfSmartAccountEnabled(networkId?: string): boolean {
+    const smartAccountEnabledNetworks = this.getSmartAccountEnabledNetworks()
+
+    return Boolean(
+      networkId &&
+        smartAccountEnabledNetworks?.includes(networkId) &&
+        Boolean(W3mFrameStorage.get(W3mFrameConstants.SMART_ACCOUNT_ENABLED))
+    )
   },
 
   isClient: typeof window !== 'undefined'

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -406,6 +406,10 @@ export class W3mFrameProvider {
     })
   }
 
+  public setSmartAccountEnabled(enabled: boolean) {
+    W3mFrameStorage.set(W3mFrameConstants.SMART_ACCOUNT_ENABLED, String(enabled))
+  }
+
   // -- Promise Handlers ------------------------------------------------
   private onConnectEmailSuccess(
     event: Extract<W3mFrameTypes.FrameEvent, { type: '@w3m-frame/CONNECT_EMAIL_SUCCESS' }>
@@ -594,6 +598,7 @@ export class W3mFrameProvider {
       { type: '@w3m-frame/GET_SMART_ACCOUNT_ENABLED_NETWORKS_SUCCESS' }
     >
   ) {
+    this.persistSmartAccountEnabledNetworks(event.payload.smartAccountEnabledNetworks)
     this.smartAccountEnabledNetworksResolver?.resolve(event.payload)
   }
 
@@ -603,6 +608,7 @@ export class W3mFrameProvider {
       { type: '@w3m-frame/GET_SMART_ACCOUNT_ENABLED_NETWORKS_ERROR' }
     >
   ) {
+    this.persistSmartAccountEnabledNetworks([])
     this.smartAccountEnabledNetworksResolver?.reject(event.payload.message)
   }
 
@@ -656,5 +662,9 @@ export class W3mFrameProvider {
 
   private persistPreferredAccount(type: 'eoa' | 'smartAccount') {
     W3mFrameStorage.set(W3mFrameConstants.PREFERRED_ACCOUNT_TYPE, type)
+  }
+
+  private persistSmartAccountEnabledNetworks(networks: number[]) {
+    W3mFrameStorage.set(W3mFrameConstants.SMART_ACCOUNT_ENABLED_NETWORKS, networks.join(','))
   }
 }


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat: add helpers to utilize smart accounts from the ui. suggest smart account creation on OTP code success. switch to CF address when accepted.
- fix: smart account creation screen
- chore: