### PR TITLE
fix: do not sync rpc callbacks multiple times

### DIFF
--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -186,6 +186,7 @@ export class Web3Modal extends Web3ModalScaffold {
 
     this.syncRequestedNetworks([...wagmiConfig.chains])
     this.syncConnectors([...wagmiConfig.connectors])
+    this.initEmailConnectorListeners([...wagmiConfig.connectors])
 
     watchConnectors(this.wagmiConfig, {
       onChange: connectors => this.syncConnectors(connectors)
@@ -404,8 +405,16 @@ export class Web3Modal extends Web3ModalScaffold {
         name: 'Email',
         provider
       })
-      this.listenEmailConnector(emailConnector)
-      this.listenModal(emailConnector)
+    }
+  }
+
+  private async initEmailConnectorListeners(
+    connectors: Web3ModalClientOptions<CoreConfig>['wagmiConfig']['connectors']
+  ) {
+    const emailConnector = connectors.find(({ id }) => id === ConstantsUtil.EMAIL_CONNECTOR_ID)
+    if (emailConnector) {
+      await this.listenEmailConnector(emailConnector)
+      await this.listenModal(emailConnector)
     }
   }
 


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: issue where email connector would re subscribe to rpc callbacks on connectors sync and cause multiple responses to be executed
- chore:

