### PR TITLE
fix: ethers fail to disconnect

### DIFF
--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -38,9 +38,9 @@ export class ModalValidator {
 
   async expectDisconnected() {
     await expect(
-      this.page.getByTestId('account-button'),
-      'Account button should not be present'
-    ).not.toBeVisible({
+      this.page.getByTestId('connect-button'),
+      'Connect button should be present'
+    ).toBeVisible({
       timeout: MAX_WAIT
     })
   }

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -252,7 +252,6 @@ export class Web3Modal extends Web3ModalScaffold {
         if (providerType === ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID) {
           const WalletConnectProvider = provider
           await (WalletConnectProvider as unknown as EthereumProvider).disconnect()
-          provider?.emit('disconnect')
           // eslint-disable-next-line no-negated-condition
         } else if (providerType !== ConstantsUtil.EMAIL_CONNECTOR_ID) {
           provider?.emit('disconnect')


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: "Failed to disconnect" error on ethers + relay connections
- chore:

## Description
Email provider does not implement `emit` which  was being fired after disconnection. This caused the client to actually disconnect, but throw an error causing desync in the UI and an error popup.

Tests were not capturing this because the UI kept the modal open and the button in loading state so "account button" was never displayed. Updated it to expect to see the connect button instead
