### PR TITLE
fix: NaN balance 

### DIFF
--- a/packages/common/src/utils/TypeUtil.ts
+++ b/packages/common/src/utils/TypeUtil.ts
@@ -77,7 +77,7 @@ export interface Balance {
   name: string
   symbol: string
   chainId: string
-  value: number
+  value?: number
   price: number
   quantity: BalanceQuantity
   iconUrl: string

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -252,7 +252,7 @@ export const CoreHelperUtil = {
   calculateBalance(array: Balance[]) {
     let sum = 0
     for (const item of array) {
-      sum += item.value
+      sum += item.value ?? 0
     }
 
     return sum


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- fix: issue where wallet balance would show NaN when having scam tokens without a `value`. 
