### PR TITLE
chore: remove fixed addresses from SA tests

### DIFF
--- a/apps/laboratory/tests/shared/fixtures/w3m-smart-account-fixture.ts
+++ b/apps/laboratory/tests/shared/fixtures/w3m-smart-account-fixture.ts
@@ -22,7 +22,10 @@ export const testModalSmartAccount = base.extend<ModalFixture & { slowModalPage:
       const tempEmail = email.getEmailAddressToUse(testInfo.parallelIndex)
 
       await modalPage.emailFlow(tempEmail, context, mailsacApiKey)
+      await modalPage.openAccount()
+      await modalPage.openSettings()
       await modalPage.switchNetwork('Sepolia')
+      await modalPage.closeModal()
       await modalPage.page.waitForTimeout(1500)
       await use(modalPage)
     },

--- a/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
@@ -34,10 +34,11 @@ export class ModalWalletPage extends ModalPage {
     await disconnectBtn.click({ force: true })
   }
 
-  async getAddress() {
+  async getAddress(): Promise<string> {
     const address = await this.page.getByTestId('account-settings-address').textContent()
     expect(address, 'Address should be present').toBeTruthy()
 
-    return address as string
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return address!
   }
 }

--- a/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
@@ -12,23 +12,18 @@ export class ModalWalletPage extends ModalPage {
   }
 
   async openSettings() {
-    await this.page.getByTestId('account-button').click()
     await this.page.getByTestId('wui-profile-button').click()
   }
 
   override async switchNetwork(network: string) {
-    await this.openSettings()
     await this.page.getByTestId('account-switch-network-button').click()
     await this.page.getByTestId(`w3m-network-switch-${network}`).click()
-    await this.page.getByTestId('w3m-header-close').click()
     await this.page.waitForTimeout(2000)
   }
 
   async togglePreferredAccountType() {
-    await this.openSettings()
     await this.page.getByTestId('account-toggle-preferred-account-type').click()
-    await this.page.getByTestId('w3m-header-close').click()
-    await this.page.waitForTimeout(2000)
+    await this.page.waitForTimeout(2500)
   }
 
   override async disconnect(): Promise<void> {
@@ -37,5 +32,12 @@ export class ModalWalletPage extends ModalPage {
     await expect(disconnectBtn, 'Disconnect button should be visible').toBeVisible()
     await expect(disconnectBtn, 'Disconnect button should be enabled').toBeEnabled()
     await disconnectBtn.click({ force: true })
+  }
+
+  async getAddress() {
+    const address = await this.page.getByTestId('account-settings-address').textContent()
+    expect(address, 'Address should be present').toBeTruthy()
+
+    return address as string
   }
 }

--- a/apps/laboratory/tests/shared/validators/ModalWalletValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalWalletValidator.ts
@@ -1,47 +1,40 @@
 import { expect } from '@playwright/test'
 import { ModalValidator } from './ModalValidator'
 
-// Each entry corresponds to web3modal${index} email address EOA
-const testEmailsEOAAddresses = [
-  '0x629EC1c38cB60E90A47464e166A422256ADd9987',
-  '0xc3425Dda0A828983d7D372153B637231b8b53b30',
-  '0xa9B505304E0DD13F6C4EaBE21d7a707d620fbce4',
-  '0xC1f94ee0cD3dF13866f8fFD2d0907694266C28CE',
-  '0xAde4446855699e2aB1bD9D2f57B31A920A7C7bec',
-  '0xE66C5Cd1b0B9162D9cb036f7452Ca5C47260757c',
-  '0x2221967773371A742C297AD5290c5db0Ed632023',
-  '0x72d8d1Cc520d715D8db8E9B34D971F783FdAe634',
-  '0x774Ef09E6d93DB7ffE31A836610EDB6202752687',
-  '0x3A24983B0527442d8249DE97cFAFabb379c9A938',
-  // Non-smart account enabled address
-  '0x63e6966E615C3852587d892B57eA6Dae27bac66D'
-]
+export const EOA = 'EOA'
+export const SMART_ACCOUNT = 'smart account'
 
-function formatAddress(address: string) {
-  return `${address.slice(0, 4)}...${address.slice(-6)}`
-}
+type AccountType = typeof EOA | typeof SMART_ACCOUNT
 
 export class ModalWalletValidator extends ModalValidator {
-  async expectActivateSmartAccountPromo() {
+  async expectActivateSmartAccountPromoVisible(visible: boolean) {
+    const promo = this.page.getByTestId('activate-smart-account-promo')
+    if (visible) {
+      await expect(promo, 'Activate smart account promo should be present').toBeVisible()
+    } else {
+      await expect(promo, 'Activate smart account promo should not be present').toBeHidden()
+    }
+  }
+
+  async expectTogglePreferredTypeVisible(visible: boolean) {
+    const toggle = this.page.getByTestId('account-toggle-preferred-account-type')
+    if (visible) {
+      await expect(toggle, 'Smart account toggle should be present').toBeVisible()
+    } else {
+      await expect(toggle, 'Smart account toggle should not be present').toBeHidden()
+    }
+  }
+
+  async expectChangePreferredAccountToShow(type: AccountType) {
     await expect(
-      this.page.getByTestId('activate-smart-account-promo'),
-      'Activate smart account promo should be present'
-    ).toContainText('unauthenticated')
+      this.page.getByTestId('account-toggle-preferred-account-type'),
+      'Preferred account toggle should show correct value'
+    ).toContainText(type)
   }
 
-  async expectSmartAccountAddress(index: number) {
+  async expectAddress(expectedAddress: string) {
     const address = this.page.getByTestId('account-settings-address')
 
-    await expect(address, 'Smart account sepolia address should be present').not.toHaveText(
-      formatAddress(testEmailsEOAAddresses[index] || '')
-    )
-  }
-
-  async expectEoaAddress(index: number) {
-    const address = this.page.getByTestId('account-settings-address')
-
-    await expect(address, 'EOA address should be present').toHaveText(
-      formatAddress(testEmailsEOAAddresses[index] || '')
-    )
+    await expect(address, 'Correct address should be present').toHaveText(expectedAddress)
   }
 }

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -68,17 +68,20 @@ testModalSmartAccount(
 
     await walletModalPage.openAccount()
     await walletModalPage.openSettings()
+
     const originalAddress = await walletModalPage.getAddress()
 
     await walletModalPage.togglePreferredAccountType()
     await walletModalValidator.expectChangePreferredAccountToShow(EOA)
     await walletModalPage.switchNetwork('Avalanche')
     await walletModalValidator.expectTogglePreferredTypeVisible(false)
-    await walletModalValidator.expectAddress(originalAddress)
 
     await walletModalPage.closeModal()
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
+
+    await walletModalPage.openSettings()
+    await walletModalValidator.expectAddress(originalAddress)
   }
 )
 

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -1,9 +1,15 @@
 import { testModalSmartAccount } from './shared/fixtures/w3m-smart-account-fixture'
 import type { ModalWalletPage } from './shared/pages/ModalWalletPage'
+import { EOA, SMART_ACCOUNT } from './shared/validators/ModalWalletValidator'
+
 import type { ModalWalletValidator } from './shared/validators/ModalWalletValidator'
 
-const NOT_ENABLED_SMART_ACCOUNT_INDEX = 10
-const NOT_ENABLED_SMART_ACCOUNT = 'test@w3ma.msdc.co'
+const NOT_ENABLED_EMAIL = 'test@w3ma.msdc.co'
+const NOT_ENABLED_EMAIL_EOA = '0x63e6966E615C3852587d892B57eA6Dae27bac66D'
+const FORMATTED_NOT_ENABLED_EMAIL_EOA = `${NOT_ENABLED_EMAIL_EOA.slice(
+  0,
+  4
+)}...${NOT_ENABLED_EMAIL_EOA.slice(-6)}`
 
 const mailsacApiKey = process.env['MAILSAC_API_KEY']
 if (!mailsacApiKey) {
@@ -22,13 +28,17 @@ testModalSmartAccount('it should sign with eoa', async ({ modalPage, modalValida
 
 testModalSmartAccount(
   'it should switch to its smart account',
-  async ({ modalPage, modalValidator }, testInfo) => {
+  async ({ modalPage, modalValidator }) => {
     const walletModalPage = modalPage as ModalWalletPage
     const walletModalValidator = modalValidator as ModalWalletValidator
 
-    await walletModalPage.togglePreferredAccountType()
+    await walletModalPage.openAccount()
+    await walletModalValidator.expectActivateSmartAccountPromoVisible(true)
+
     await walletModalPage.openSettings()
-    await walletModalValidator.expectSmartAccountAddress(testInfo.parallelIndex)
+    await walletModalValidator.expectChangePreferredAccountToShow(SMART_ACCOUNT)
+    await walletModalPage.togglePreferredAccountType()
+    await walletModalValidator.expectChangePreferredAccountToShow(EOA)
   }
 )
 
@@ -38,7 +48,11 @@ testModalSmartAccount(
     const walletModalPage = modalPage as ModalWalletPage
     const walletModalValidator = modalValidator as ModalWalletValidator
 
+    await walletModalPage.openAccount()
+    await walletModalPage.openSettings()
     await walletModalPage.togglePreferredAccountType()
+    await walletModalPage.closeModal()
+    await walletModalPage.page.waitForTimeout(1000)
 
     await walletModalPage.sign()
     await walletModalPage.approveSign()
@@ -48,31 +62,47 @@ testModalSmartAccount(
 
 testModalSmartAccount(
   'it should return to an eoa when switching to a non supported network',
-  async ({ modalPage, modalValidator }, testInfo) => {
+  async ({ modalPage, modalValidator }) => {
     const walletModalPage = modalPage as ModalWalletPage
     const walletModalValidator = modalValidator as ModalWalletValidator
 
-    await walletModalPage.togglePreferredAccountType()
-    await walletModalPage.switchNetwork('Avalanche')
+    await walletModalPage.openAccount()
     await walletModalPage.openSettings()
-    await walletModalValidator.expectEoaAddress(testInfo.parallelIndex)
+    const originalAddress = await walletModalPage.getAddress()
+
+    await walletModalPage.togglePreferredAccountType()
+    await walletModalValidator.expectChangePreferredAccountToShow(EOA)
+    await walletModalPage.switchNetwork('Avalanche')
+    await walletModalValidator.expectTogglePreferredTypeVisible(false)
+    await walletModalValidator.expectAddress(originalAddress)
+
+    await walletModalPage.closeModal()
+    await walletModalPage.openAccount()
+    await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
   }
 )
 
 testModalSmartAccount(
-  'it should use an eoa when disconnecting and connecting to a not enabled address',
+  'it should use an eoa and not propose flow when disconnecting and connecting to a not enabled address',
   async ({ modalPage, modalValidator, context }) => {
     const walletModalPage = modalPage as ModalWalletPage
     const walletModalValidator = modalValidator as ModalWalletValidator
 
+    await walletModalPage.openAccount()
+    await walletModalPage.openSettings()
     await walletModalPage.togglePreferredAccountType()
     await walletModalPage.disconnect()
     await walletModalPage.page.waitForTimeout(2500)
 
-    await walletModalPage.emailFlow(NOT_ENABLED_SMART_ACCOUNT, context, mailsacApiKey)
-    await walletModalPage.switchNetwork('Sepolia')
+    await walletModalPage.emailFlow(NOT_ENABLED_EMAIL, context, mailsacApiKey)
+    await walletModalPage.openAccount()
     await walletModalPage.openSettings()
+    await walletModalPage.switchNetwork('Sepolia')
 
-    await walletModalValidator.expectEoaAddress(NOT_ENABLED_SMART_ACCOUNT_INDEX)
+    await walletModalValidator.expectAddress(FORMATTED_NOT_ENABLED_EMAIL_EOA)
+    await walletModalPage.closeModal()
+
+    await walletModalPage.openAccount()
+    await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
   }
 )

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -5,11 +5,6 @@ import { EOA, SMART_ACCOUNT } from './shared/validators/ModalWalletValidator'
 import type { ModalWalletValidator } from './shared/validators/ModalWalletValidator'
 
 const NOT_ENABLED_EMAIL = 'test@w3ma.msdc.co'
-const NOT_ENABLED_EMAIL_EOA = '0x63e6966E615C3852587d892B57eA6Dae27bac66D'
-const FORMATTED_NOT_ENABLED_EMAIL_EOA = `${NOT_ENABLED_EMAIL_EOA.slice(
-  0,
-  4
-)}...${NOT_ENABLED_EMAIL_EOA.slice(-6)}`
 
 const mailsacApiKey = process.env['MAILSAC_API_KEY']
 if (!mailsacApiKey) {
@@ -75,8 +70,9 @@ testModalSmartAccount(
     await walletModalValidator.expectChangePreferredAccountToShow(EOA)
     await walletModalPage.switchNetwork('Avalanche')
     await walletModalValidator.expectTogglePreferredTypeVisible(false)
-
     await walletModalPage.closeModal()
+    await walletModalPage.page.waitForTimeout(1000)
+
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
 
@@ -101,9 +97,9 @@ testModalSmartAccount(
     await walletModalPage.openAccount()
     await walletModalPage.openSettings()
     await walletModalPage.switchNetwork('Sepolia')
-
-    await walletModalValidator.expectAddress(FORMATTED_NOT_ENABLED_EMAIL_EOA)
+    await walletModalValidator.expectTogglePreferredTypeVisible(false)
     await walletModalPage.closeModal()
+    await walletModalPage.page.waitForTimeout(1000)
 
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- chore: refactor SA tests to prevent using fixed ids which were causing issues when ran from different environments with different keys.
- chore: unpack `openSettings` and other utils into single actions to allow for more flexible testing

