### PR TITLE
remove siwe signOut function on high level packages

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -246,9 +246,6 @@ export class Web3Modal extends Web3ModalScaffold {
         const providerType = EthersStoreUtil.state.providerType
         localStorage.removeItem(EthersConstantsUtil.WALLET_ID)
         EthersStoreUtil.reset()
-        if (siweConfig?.options?.signOutOnDisconnect) {
-          await siweConfig.signOut()
-        }
         if (providerType === ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID) {
           const WalletConnectProvider = provider
           await (WalletConnectProvider as unknown as EthereumProvider).disconnect()

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -234,9 +234,6 @@ export class Web3Modal extends Web3ModalScaffold {
         const providerType = EthersStoreUtil.state.providerType
         localStorage.removeItem(EthersConstantsUtil.WALLET_ID)
         EthersStoreUtil.reset()
-        if (siweConfig?.options?.signOutOnDisconnect) {
-          await siweConfig.signOut()
-        }
         if (providerType === ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID) {
           const WalletConnectProvider = provider
           await (WalletConnectProvider as unknown as EthereumProvider).disconnect()

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -163,9 +163,6 @@ export class Web3Modal extends Web3ModalScaffold {
 
       disconnect: async () => {
         await disconnect(this.wagmiConfig)
-        if (siweConfig?.options?.signOutOnDisconnect) {
-          await siweConfig.signOut()
-        }
       },
 
       signMessage: async message => signMessage(this.wagmiConfig, { message })


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: Web3Modal was calling the SIWE's signOut function twice.
the signOut function from SIWE is already called internally in [`scaffold/src/modal/w3m-modal`](https://github.com/WalletConnect/web3modal/blob/0478feb5b420c2eefcadd3410f97e2d8bffbbecf/packages/scaffold/src/modal/w3m-modal/index.ts#L181)
![image](https://github.com/WalletConnect/web3modal/assets/66949816/8e2885de-77b2-4162-8419-9e12f1f1c532)

Context: https://walletconnect.slack.com/archives/C03RVH94K5K/p1713282453076899
- chore:

# Associated Issues

closes #...
