### PR TITLE
fix: switch network test flakyness

### DIFF
--- a/apps/laboratory/src/components/Solana/SolanaWriteContractTest.tsx
+++ b/apps/laboratory/src/components/Solana/SolanaWriteContractTest.tsx
@@ -101,7 +101,11 @@ export function SolanaWriteContractTest() {
   }
 
   return (
-    <Button isDisabled={loading} data-testid="sign-message-button" onClick={onIncrementCounter}>
+    <Button
+      isDisabled={loading}
+      data-testid="increment-counter-with-sign-button"
+      onClick={onIncrementCounter}
+    >
       Increment Counter With Sign
     </Button>
   )

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -28,7 +28,8 @@ testMEmail('it should switch network and sign', async ({ modalPage, modalValidat
   let targetChain = 'Polygon'
   await modalPage.switchNetwork(targetChain)
   await modalValidator.expectNetwork(targetChain)
-  await modalPage.page.waitForTimeout(3500)
+  await modalPage.closeModal()
+  await modalPage.page.waitForTimeout(1500)
   await modalPage.sign()
   await modalPage.approveSign()
   await modalValidator.expectAcceptedSign()
@@ -38,7 +39,8 @@ testMEmail('it should switch network and sign', async ({ modalPage, modalValidat
   targetChain = 'Ethereum'
   await modalPage.switchNetwork(targetChain)
   await modalValidator.expectNetwork(targetChain)
-  await modalPage.page.waitForTimeout(3500)
+  await modalPage.closeModal()
+  await modalPage.page.waitForTimeout(1500)
   await modalPage.sign()
   await modalPage.approveSign()
   await modalValidator.expectAcceptedSign()

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -210,7 +210,8 @@ export class ModalPage {
     await this.page.getByTestId('account-button').click()
     await this.page.getByTestId('w3m-account-select-network').click()
     await this.page.getByTestId(`w3m-network-switch-${network}`).click()
-    await this.page.getByTestId('w3m-header-close').click()
+    // Network switch might take a second or two
+    await this.page.waitForTimeout(2000)
   }
 
   async clickWalletDeeplink() {

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -53,7 +53,7 @@ export class ModalValidator {
   }
 
   async expectNetwork(network: string) {
-    const networkButton = this.page.locator('wui-network-button')
+    const networkButton = this.page.getByTestId('w3m-account-select-network')
     await expect(networkButton, `Network button should contain text ${network}`).toHaveText(
       network,
       {

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -51,6 +51,7 @@ testConnectedMW(
 
       const chainName = chains[index] ?? DEFAULT_CHAIN_NAME
       await modalPage.switchNetwork(chainName)
+      await modalPage.closeModal()
       await modalPage.sign()
       await walletValidator.expectReceivedSign({ chainName })
       await walletPage.handleRequest({ accept: true })

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -51,6 +51,7 @@ testConnectedMW(
 
       const chainName = chains[index] ?? DEFAULT_CHAIN_NAME
       await modalPage.switchNetwork(chainName)
+      await modalValidator.expectNetwork(chainName)
       await modalPage.closeModal()
       await modalPage.sign()
       await walletValidator.expectReceivedSign({ chainName })

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -41,7 +41,7 @@ testConnectedMW(
 testConnectedMW(
   'it should switch networks and sign',
   async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
-    const chains = modalPage.library === 'solana' ? ['Solana'] : ['Polygon', 'Ethereum']
+    const chains = modalPage.library === 'solana' ? ['Solana Devnet'] : ['Polygon', 'Ethereum']
 
     // Run them one after another
     async function processChain(index: number) {
@@ -50,11 +50,13 @@ testConnectedMW(
       }
 
       const chainName = chains[index] ?? DEFAULT_CHAIN_NAME
+      // For Solana, even though we switch to Solana Devnet, the chain name on the wallet page is still Solana
+      const chainNameOnWalletPage = modalPage.library === 'solana' ? 'Solana' : chainName
       await modalPage.switchNetwork(chainName)
       await modalValidator.expectNetwork(chainName)
       await modalPage.closeModal()
       await modalPage.sign()
-      await walletValidator.expectReceivedSign({ chainName })
+      await walletValidator.expectReceivedSign({ chainName: chainNameOnWalletPage })
       await walletPage.handleRequest({ accept: true })
       await modalValidator.expectAcceptedSign()
 


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes
Fixes isssue where switch network test would have flaky behavior due to the modal being closed too quickly, causing following modal openings to close prematurely. 
Modified the test to better reflect user flow by expecting the screen to return to account view and show the apropiate network. 


## Screenshot
<img width="639" alt="image" src="https://github.com/WalletConnect/web3modal/assets/12738697/41242176-b2d4-48e8-baad-3c37d79f6632"> 🤣 

