### PR TITLE
fix: e2e test decrease timeouts

### DIFF
--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -29,18 +29,14 @@ testMEmail('it should switch network and sign', async ({ modalPage, modalValidat
   await modalPage.switchNetwork(targetChain)
   await modalValidator.expectNetwork(targetChain)
   await modalPage.closeModal()
-  await modalPage.page.waitForTimeout(1500)
   await modalPage.sign()
   await modalPage.approveSign()
   await modalValidator.expectAcceptedSign()
-
-  await modalPage.page.waitForTimeout(2000)
 
   targetChain = 'Ethereum'
   await modalPage.switchNetwork(targetChain)
   await modalValidator.expectNetwork(targetChain)
   await modalPage.closeModal()
-  await modalPage.page.waitForTimeout(1500)
   await modalPage.sign()
   await modalPage.approveSign()
   await modalValidator.expectAcceptedSign()

--- a/apps/laboratory/tests/shared/fixtures/w3m-smart-account-fixture.ts
+++ b/apps/laboratory/tests/shared/fixtures/w3m-smart-account-fixture.ts
@@ -26,7 +26,6 @@ export const testModalSmartAccount = base.extend<ModalFixture & { slowModalPage:
       await modalPage.openSettings()
       await modalPage.switchNetwork('Sepolia')
       await modalPage.closeModal()
-      await modalPage.page.waitForTimeout(1500)
       await use(modalPage)
     },
     { timeout: 90_000 }

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -210,8 +210,6 @@ export class ModalPage {
     await this.page.getByTestId('account-button').click()
     await this.page.getByTestId('w3m-account-select-network').click()
     await this.page.getByTestId(`w3m-network-switch-${network}`).click()
-    // Network switch might take a second or two
-    await this.page.waitForTimeout(2000)
   }
 
   async clickWalletDeeplink() {
@@ -226,5 +224,7 @@ export class ModalPage {
 
   async closeModal() {
     await this.page.getByTestId('w3m-header-close')?.click?.()
+    // Wait for the modal fade out animation
+    await this.page.waitForTimeout(300)
   }
 }

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -35,7 +35,6 @@ testModalSmartAccount(
     await walletModalValidator.expectChangePreferredAccountToShow(EOA)
 
     await walletModalPage.closeModal()
-    await walletModalPage.page.waitForTimeout(1000)
 
     await walletModalPage.sign()
     await walletModalPage.approveSign()
@@ -59,7 +58,6 @@ testModalSmartAccount(
     await walletModalPage.switchNetwork('Avalanche')
     await walletModalValidator.expectTogglePreferredTypeVisible(false)
     await walletModalPage.closeModal()
-    await walletModalPage.page.waitForTimeout(1000)
 
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
@@ -94,7 +92,6 @@ testModalSmartAccount(
     await walletModalPage.switchNetwork('Sepolia')
     await walletModalValidator.expectTogglePreferredTypeVisible(false)
     await walletModalPage.closeModal()
-    await walletModalPage.page.waitForTimeout(1000)
 
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)


### PR DESCRIPTION
# Changes

We have fadeout animation of the modal. In some test scenarios, are opening the approved transaction page right after we close the modal. If we do this without waiting for the main modal to be closed, this goes into a state where the overlay does not disappear.

This PR introduces some optimizations to our timeouts and add the timeout for the fade out animation only and removes other extra timeouts from tests.
