### PR TITLE
chore: don't use /usr/bin/env

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -13,4 +13,4 @@ RUN npm run playwright:install
 
 ENV TIMING_LOGS=true
 
-CMD ["./docker-canary.sh"]
+CMD ["bash", "./docker-canary.sh"]

--- a/apps/laboratory/docker-canary.sh
+++ b/apps/laboratory/docker-canary.sh
@@ -1,8 +1,6 @@
-#!/usr/env/bin
-
 # Not adding `set -e` so that S3 upload happens regardless
 
-npm run playwright:canary:test
+npm run playwright:test:canary
 
 destination="s3://$TEST_RESULTS_BUCKET/web3modal-canary/$(date --iso-8601=seconds)/test-results/"
 echo "Uploading test results to $destination"


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- chore: fixes that /usr/bin/env wasn't in the canary Docker image and fix canary script name

# Associated Issues

N/A
