### PR TITLE
fix: don't use random emails in tests

### DIFF
--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 import { testMEmail } from './shared/fixtures/w3m-email-fixture'
 import { SECURE_WEBSITE_URL } from './shared/constants'
-import { INDEX_OFFSET } from './shared/utils/email'
 
 testMEmail.beforeEach(async ({ modalValidator }) => {
   await modalValidator.expectConnected()
@@ -46,13 +45,4 @@ testMEmail('it should switch network and sign', async ({ modalPage, modalValidat
 testMEmail('it should disconnect correctly', async ({ modalPage, modalValidator }) => {
   await modalPage.disconnect()
   await modalValidator.expectDisconnected()
-})
-
-testMEmail('it should update email', async ({ modalPage }, testInfo) => {
-  const mailsacApiKey = process.env['MAILSAC_API_KEY']
-  if (!mailsacApiKey) {
-    throw new Error('MAILSAC_API_KEY is not set')
-  }
-
-  await modalPage.updateEmail(mailsacApiKey, INDEX_OFFSET + testInfo.parallelIndex)
 })

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 import { testMEmail } from './shared/fixtures/w3m-email-fixture'
 import { SECURE_WEBSITE_URL } from './shared/constants'
+import { INDEX_OFFSET } from './shared/utils/email'
 
 testMEmail.beforeEach(async ({ modalValidator }) => {
   await modalValidator.expectConnected()
@@ -47,11 +48,11 @@ testMEmail('it should disconnect correctly', async ({ modalPage, modalValidator 
   await modalValidator.expectDisconnected()
 })
 
-testMEmail('it should update email', async ({ modalPage }) => {
+testMEmail('it should update email', async ({ modalPage }, testInfo) => {
   const mailsacApiKey = process.env['MAILSAC_API_KEY']
   if (!mailsacApiKey) {
     throw new Error('MAILSAC_API_KEY is not set')
   }
 
-  await modalPage.updateEmail(mailsacApiKey)
+  await modalPage.updateEmail(mailsacApiKey, INDEX_OFFSET + testInfo.parallelIndex)
 })

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -232,9 +232,9 @@ export class ModalPage {
     await this.page.waitForTimeout(300)
   }
 
-  async updateEmail(mailsacApiKey: string) {
+  async updateEmail(mailsacApiKey: string, index: number) {
     const email = new Email(mailsacApiKey)
-    const newEmailAddress = email.getEmailAddressToUse(1)
+    const newEmailAddress = email.getEmailAddressToUse(index)
 
     await this.page.getByTestId('account-button').click()
     await this.page.getByTestId('w3m-account-email-update').click()

--- a/apps/laboratory/tests/shared/utils/email.ts
+++ b/apps/laboratory/tests/shared/utils/email.ts
@@ -6,7 +6,6 @@ const APPROVE_URL_REGEX = /https:\/\/register.*/u
 const OTP_CODE_REGEX = /\d{3}\s?\d{3}/u
 const EMAIL_DOMAIN = 'web3modal.msdc.co'
 export const NOT_ENABLED_DOMAIN = 'w3ma.msdc.co'
-export const INDEX_OFFSET = 8
 
 export class Email {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/apps/laboratory/tests/shared/utils/email.ts
+++ b/apps/laboratory/tests/shared/utils/email.ts
@@ -1,5 +1,4 @@
 import { Mailsac } from '@mailsac/api'
-import { randomBytes } from 'crypto'
 const EMAIL_CHECK_TIMEOUT = 1000
 const MAX_EMAIL_CHECK = 16
 const EMAIL_APPROVE_BUTTON_TEXT = 'Approve this login'
@@ -7,6 +6,7 @@ const APPROVE_URL_REGEX = /https:\/\/register.*/u
 const OTP_CODE_REGEX = /\d{3}\s?\d{3}/u
 const EMAIL_DOMAIN = 'web3modal.msdc.co'
 export const NOT_ENABLED_DOMAIN = 'w3ma.msdc.co'
+export const INDEX_OFFSET = 8
 
 export class Email {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -78,8 +78,6 @@ export class Email {
   }
 
   getEmailAddressToUse(index: number, domain = EMAIL_DOMAIN): string {
-    const prefix = randomBytes(12).toString('hex')
-
-    return `${prefix}-w${index}@${domain}`
+    return `w3m-w${index}@${domain}`
   }
 }


### PR DESCRIPTION
Reuse same set of emails for tests. Introduce offset for email change emails. Number of emails we consume is currently `numberOfWorkers * 2` (16 at the moment)
