### PR TITLE
Chore/sa sign tests

### DIFF
--- a/apps/laboratory/src/components/Ethers/EthersModalInfo.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersModalInfo.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+import { useWeb3ModalAccount } from '@web3modal/ethers/react'
+
+import { Web3ModalInfo } from '../Web3ModalInfo'
+
+export function EthersModalInfo() {
+  const { isConnected, address, chainId } = useWeb3ModalAccount()
+
+  return isConnected ? <Web3ModalInfo address={address} chainId={chainId} /> : null
+}

--- a/apps/laboratory/src/components/Ethers/EthersSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersSignMessageTest.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@chakra-ui/react'
+import { useState } from 'react'
 import { useWeb3ModalAccount, useWeb3ModalProvider } from '@web3modal/ethers/react'
 import { BrowserProvider, JsonRpcSigner } from 'ethers'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
@@ -8,6 +9,7 @@ export function EthersSignMessageTest() {
   const toast = useChakraToast()
   const { address, chainId } = useWeb3ModalAccount()
   const { walletProvider } = useWeb3ModalProvider()
+  const [signature, setSignature] = useState<string | undefined>()
 
   async function onSignMessage() {
     try {
@@ -16,8 +18,8 @@ export function EthersSignMessageTest() {
       }
       const provider = new BrowserProvider(walletProvider, chainId)
       const signer = new JsonRpcSigner(provider, address)
-      const signature = await signer?.signMessage('Hello Web3Modal Ethers')
-
+      const sig = await signer?.signMessage('Hello Web3Modal!')
+      setSignature(sig)
       toast({
         title: ConstantsUtil.SigningSucceededToastTitle,
         description: signature,
@@ -33,8 +35,13 @@ export function EthersSignMessageTest() {
   }
 
   return (
-    <Button data-testid="sign-message-button" onClick={onSignMessage}>
-      Sign Message
-    </Button>
+    <>
+      <Button data-testid="sign-message-button" onClick={onSignMessage} width="auto">
+        Sign Message
+      </Button>
+      <div data-testid="w3m-signature" hidden>
+        {signature}
+      </div>
+    </>
   )
 }

--- a/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+
+import { useAccount } from 'wagmi'
+import { Web3ModalInfo } from '../Web3ModalInfo'
+
+export function WagmiModalInfo() {
+  const { isConnected, address, chainId } = useAccount()
+
+  return isConnected ? <Web3ModalInfo address={address} chainId={chainId} /> : null
+}

--- a/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
@@ -10,13 +10,15 @@ export function WagmiSignMessageTest() {
   const { signMessageAsync } = useSignMessage()
   const { status } = useAccount()
   const isConnected = status === 'connected'
+  const [signature, setSignature] = React.useState<string | undefined>()
 
   async function onSignMessage() {
     try {
-      const signature = await signMessageAsync({ message: 'Hello Web3Modal!' })
+      const sig = await signMessageAsync({ message: 'Hello Web3Modal!' })
+      setSignature(sig)
       toast({
         title: ConstantsUtil.SigningSucceededToastTitle,
-        description: signature,
+        description: sig,
         type: 'success'
       })
     } catch {
@@ -29,8 +31,14 @@ export function WagmiSignMessageTest() {
   }
 
   return (
-    <Button data-testid="sign-message-button" onClick={onSignMessage} isDisabled={!isConnected}>
-      Sign Message
-    </Button>
+    <>
+      <Button data-testid="sign-message-button" onClick={onSignMessage} isDisabled={!isConnected}>
+        Sign Message
+      </Button>
+      <div data-testid="w3m-signature" hidden>
+        {' '}
+        {signature}
+      </div>
+    </>
   )
 }

--- a/apps/laboratory/src/components/Web3ModalInfo.tsx
+++ b/apps/laboratory/src/components/Web3ModalInfo.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+
+import {
+  StackDivider,
+  Card,
+  CardHeader,
+  Heading,
+  CardBody,
+  Box,
+  Stack,
+  Text
+} from '@chakra-ui/react'
+
+export function Web3ModalInfo({ address, chainId }: { address?: string; chainId?: number }) {
+  return (
+    <Card marginTop={10} marginBottom={10}>
+      <CardHeader>
+        <Heading size="md">Account Information</Heading>
+      </CardHeader>
+
+      <CardBody>
+        <Stack divider={<StackDivider />} spacing="4">
+          <Box>
+            <Heading size="xs" textTransform="uppercase" pb="2">
+              Address
+            </Heading>
+            <Text data-testid="w3m-address">{address}</Text>
+          </Box>
+
+          <Box>
+            <Heading size="xs" textTransform="uppercase" pb="2">
+              Chain Id
+            </Heading>
+            <Text data-testid="w3m-chain-id">{chainId}</Text>
+          </Box>
+        </Stack>
+      </CardBody>
+    </Card>
+  )
+}

--- a/apps/laboratory/src/pages/library/ethers-email.tsx
+++ b/apps/laboratory/src/pages/library/ethers-email.tsx
@@ -4,6 +4,7 @@ import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersTests } from '../../components/Ethers/EthersTests'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
 const modal = createWeb3Modal({
   ethersConfig: defaultConfig({
@@ -28,6 +29,7 @@ export default function Ethers() {
   return (
     <>
       <Web3ModalButtons />
+      <EthersModalInfo />
       <EthersTests />
     </>
   )

--- a/apps/laboratory/src/pages/library/ethers-wallet.tsx
+++ b/apps/laboratory/src/pages/library/ethers-wallet.tsx
@@ -4,6 +4,7 @@ import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersTests } from '../../components/Ethers/EthersTests'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
 const modal = createWeb3Modal({
   ethersConfig: defaultConfig({
@@ -29,6 +30,7 @@ export default function Ethers() {
   return (
     <>
       <Web3ModalButtons />
+      <EthersModalInfo />
       <EthersTests />
     </>
   )

--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -4,6 +4,7 @@ import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
+import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
 const modal = createWeb3Modal({
   ethersConfig: defaultConfig({
@@ -27,6 +28,7 @@ export default function Ethers() {
   return (
     <>
       <Web3ModalButtons />
+      <EthersModalInfo />
       <EthersTests />
     </>
   )

--- a/apps/laboratory/src/pages/library/wagmi-email.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-email.tsx
@@ -8,6 +8,7 @@ import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { WagmiConstantsUtil } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
+import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
@@ -43,6 +44,7 @@ export default function Wagmi() {
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <Web3ModalButtons />
+        <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>
     </WagmiProvider>

--- a/apps/laboratory/src/pages/library/wagmi-wallet.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-wallet.tsx
@@ -8,6 +8,7 @@ import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { WagmiConstantsUtil } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
+import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
@@ -44,6 +45,7 @@ export default function Wagmi() {
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <Web3ModalButtons />
+        <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>
     </WagmiProvider>

--- a/apps/laboratory/src/pages/library/wagmi.tsx
+++ b/apps/laboratory/src/pages/library/wagmi.tsx
@@ -7,6 +7,7 @@ import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { WagmiConstantsUtil } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
+import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
@@ -35,6 +36,7 @@ export default function Wagmi() {
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <Web3ModalButtons />
+        <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>
     </WagmiProvider>

--- a/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
@@ -32,11 +32,24 @@ export class ModalWalletPage extends ModalPage {
     await this.page.getByTestId('connect-button').waitFor({ state: 'visible', timeout: 5000 })
   }
 
-  async getAddress(): Promise<string> {
-    const address = await this.page.getByTestId('account-settings-address').textContent()
+  async getAddress(): Promise<`0x${string}`> {
+    const address = await this.page.getByTestId('w3m-address').textContent()
     expect(address, 'Address should be present').toBeTruthy()
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return address!
+    return address as `0x${string}`
+  }
+
+  async getChainId(): Promise<number> {
+    const chainId = await this.page.getByTestId('w3m-chain-id').textContent()
+    expect(chainId, 'Chain ID should be present').toBeTruthy()
+
+    return Number(chainId)
+  }
+
+  async getSignature(): Promise<`0x${string}`> {
+    const signature = await this.page.getByTestId('w3m-signature').textContent()
+    expect(signature, 'Signature should be present').toBeTruthy()
+
+    return signature as `0x${string}`
   }
 }

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -68,6 +68,7 @@ export class ModalValidator {
       timeout: 30 * 1000
     })
     const closeButton = this.page.locator('#toast-close-button')
+
     await expect(closeButton).toBeVisible()
     await closeButton.click()
   }

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -2,6 +2,15 @@ import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import { ConstantsUtil } from '../../../src/utils/ConstantsUtil'
 import { getMaximumWaitConnections } from '../utils/timeouts'
+import { createPublicClient, http } from 'viem'
+
+function getTransport({ chainId }: { chainId: number }) {
+  const RPC_URL = 'https://rpc.walletconnect.com'
+
+  return http(
+    `${RPC_URL}/v1/?chainId=eip155:${chainId}&projectId=${process.env['NEXT_PUBLIC_PROJECT_ID']}`
+  )
+}
 
 const MAX_WAIT = getMaximumWaitConnections()
 
@@ -52,6 +61,12 @@ export class ModalValidator {
     })
   }
 
+  async expectAddress(expectedAddress: string) {
+    const address = this.page.getByTestId('w3m-address')
+
+    await expect(address, 'Correct address should be present').toHaveText(expectedAddress)
+  }
+
   async expectNetwork(network: string) {
     const networkButton = this.page.getByTestId('w3m-account-select-network')
     await expect(networkButton, `Network button should contain text ${network}`).toHaveText(
@@ -84,5 +99,18 @@ export class ModalValidator {
     await expect(switchNetworkButton, `Switched network should include ${network}`).toContainText(
       network
     )
+  }
+
+  async expectValidSignature(signature: `0x${string}`, address: `0x${string}`, chainId: number) {
+    const publicClient = createPublicClient({
+      transport: getTransport({ chainId })
+    })
+    const isVerified = await publicClient.verifyMessage({
+      message: 'Hello Web3Modal!',
+      address,
+      signature
+    })
+
+    expect(isVerified).toBe(true)
   }
 }

--- a/apps/laboratory/tests/shared/validators/ModalWalletValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalWalletValidator.ts
@@ -1,14 +1,5 @@
 import { expect } from '@playwright/test'
 import { ModalValidator } from './ModalValidator'
-import { createPublicClient, http } from 'viem'
-
-function getTransport({ chainId }: { chainId: number }) {
-  const RPC_URL = 'https://rpc.walletconnect.com'
-
-  return http(
-    `${RPC_URL}/v1/?chainId=eip155:${chainId}&projectId=${process.env['NEXT_PUBLIC_PROJECT_ID']}`
-  )
-}
 
 export const EOA = 'EOA'
 export const SMART_ACCOUNT = 'smart account'
@@ -41,34 +32,11 @@ export class ModalWalletValidator extends ModalValidator {
     ).toContainText(type)
   }
 
-  async expectAddress(expectedAddress: string) {
-    const address = this.page.getByTestId('w3m-address')
-
-    await expect(address, 'Correct address should be present').toHaveText(expectedAddress)
-  }
-
   override async expectSwitchedNetwork(network: string) {
     const switchNetworkButton = this.page.getByTestId('account-switch-network-button')
     await expect(switchNetworkButton).toBeVisible()
     await expect(switchNetworkButton, `Switched network should include ${network}`).toContainText(
       network
     )
-  }
-
-  async expectValid6492Signature(
-    signature: `0x${string}`,
-    address: `0x${string}`,
-    chainId: number
-  ) {
-    const publicClient = createPublicClient({
-      transport: getTransport({ chainId })
-    })
-    const isVerified = await publicClient.verifyMessage({
-      message: 'Hello Web3Modal!',
-      address,
-      signature
-    })
-
-    expect(isVerified).toBe(true)
   }
 }

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -117,6 +117,6 @@ testModalSmartAccount(
     const signature = await walletModalPage.getSignature()
     const address = await walletModalPage.getAddress()
     const chainId = await walletModalPage.getChainId()
-    await walletModalValidator.expectValid6492Signature(signature, address, chainId)
+    await walletModalValidator.expectValidSignature(signature, address, chainId)
   }
 )

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -48,10 +48,10 @@ testModalSmartAccount(
     const walletModalPage = modalPage as ModalWalletPage
     const walletModalValidator = modalValidator as ModalWalletValidator
 
+    const originalAddress = await walletModalPage.getAddress()
+
     await walletModalPage.openAccount()
     await walletModalPage.openSettings()
-
-    const originalAddress = await walletModalPage.getAddress()
 
     await walletModalPage.togglePreferredAccountType()
     await walletModalValidator.expectChangePreferredAccountToShow(EOA)
@@ -62,8 +62,8 @@ testModalSmartAccount(
 
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
+    await walletModalPage.closeModal()
 
-    await walletModalPage.openSettings()
     await walletModalValidator.expectAddress(originalAddress)
   }
 )
@@ -96,5 +96,27 @@ testModalSmartAccount(
 
     await walletModalPage.openAccount()
     await walletModalValidator.expectActivateSmartAccountPromoVisible(false)
+  }
+)
+
+testModalSmartAccount(
+  'it should properly sign with a 6492 signature',
+  async ({ modalPage, modalValidator }) => {
+    const walletModalPage = modalPage as ModalWalletPage
+    const walletModalValidator = modalValidator as ModalWalletValidator
+
+    await walletModalPage.openAccount()
+    await walletModalPage.openSettings()
+    await walletModalPage.togglePreferredAccountType()
+    await walletModalValidator.expectChangePreferredAccountToShow(EOA)
+    await walletModalPage.closeModal()
+
+    await walletModalPage.sign()
+    await walletModalPage.approveSign()
+    await walletModalValidator.expectAcceptedSign()
+    const signature = await walletModalPage.getSignature()
+    const address = await walletModalPage.getAddress()
+    const chainId = await walletModalPage.getChainId()
+    await walletModalValidator.expectValid6492Signature(signature, address, chainId)
   }
 )


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- Adds W3m info section with `address` and `chainId`
- Adds `getAddress`, `getChainId` and `expectValidSignature` to `ModalValidator`
- Adds test to check for 6942 signature validity on smart-accounts

## Notes
Requires https://github.com/WalletConnect/secure-web3modal/pull/123
