### PR TITLE
chore: add apple app site association

### DIFF
--- a/apps/laboratory/public/.well-known/apple-app-site-association
+++ b/apps/laboratory/public/.well-known/apple-app-site-association
@@ -1,0 +1,19 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "W5R8AG9K22.com.walletconnect.dapp",
+        "paths": ["/dapp*"]
+      },
+      {
+        "appID": "W5R8AG9K22.com.walletconnect.walletapp",
+        "paths": ["/wallet*"]
+      },
+      {
+        "appID": "W5R8AG9K22.com.walletconnect.universal-link-test",
+        "paths": ["/test*"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add `.well-known/apple-app-site-association` to Lab for testing purposes of mobile clients
