### PR TITLE
fix: apple-app-site-association content type header

### DIFF
--- a/apps/laboratory/next.config.js
+++ b/apps/laboratory/next.config.js
@@ -3,7 +3,15 @@ const nextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
   distDir: 'out',
-  cleanDistDir: true
+  cleanDistDir: true,
+  async headers() {
+    return [
+      {
+        source: '/.well-known/apple-app-site-association',
+        headers: [{ key: 'content-type', value: 'application/json' }]
+      }
+    ]
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
`apple-app-site-association` didn't have `application/json` content type