### PR TITLE
refactor: add in-app browser check for mobile

### DIFF
--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -4,6 +4,10 @@ import type { CaipAddress, LinkingRecord, CaipNetwork } from './TypeUtil.js'
 
 export const CoreHelperUtil = {
   isInAppBrowser() {
+    if (typeof window !== 'undefined') {
+      return Boolean(/WebKit|wv|MetaMaskMobile|Phantom/u.test(navigator.userAgent))
+    }
+
     return false
   },
 
@@ -20,16 +24,7 @@ export const CoreHelperUtil = {
 
   isMobile() {
     if (typeof window !== 'undefined') {
-      return (
-        // In app browser
-        Boolean(/WebKit|wv|MetaMaskMobile|Phantom/u.test(navigator.userAgent)) ||
-        // Mobile device
-        Boolean(
-          /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
-        ) ||
-        // Touch screen
-        Boolean(window.matchMedia('(pointer:coarse)').matches)
-      )
+      return this.isInAppBrowser() || this.isMobileDevice()
     }
 
     return false

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -4,17 +4,14 @@ import type { CaipAddress, LinkingRecord, CaipNetwork } from './TypeUtil.js'
 
 export const CoreHelperUtil = {
   isInAppBrowser() {
-    if (typeof window !== 'undefined') {
-      return Boolean(/WebKit|wv|MetaMaskMobile|Phantom/u.test(navigator.userAgent))
-    }
-
     return false
   },
 
   isMobileDevice() {
     if (typeof window !== 'undefined') {
       return Boolean(
-        /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
+        window.matchMedia('(pointer:coarse)').matches ||
+          /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
       )
     }
 

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -3,11 +3,30 @@ import { ConstantsUtil } from './ConstantsUtil.js'
 import type { CaipAddress, LinkingRecord, CaipNetwork } from './TypeUtil.js'
 
 export const CoreHelperUtil = {
-  isMobile() {
+  isInAppBrowser() {
+    if (typeof window !== 'undefined') {
+      return Boolean(/WebKit|(wv)|MetaMaskMobile|Phantom|/u.test(navigator.userAgent))
+    }
+
+    return false
+  },
+
+  isMobileDevice() {
     if (typeof window !== 'undefined') {
       return Boolean(
-        window.matchMedia('(pointer:coarse)').matches ||
-          /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
+      )
+    }
+
+    return false
+  },
+
+  isMobile() {
+    if (typeof window !== 'undefined') {
+      return (
+        this.isInAppBrowser() ||
+        this.isMobileDevice() ||
+        Boolean(window.matchMedia('(pointer:coarse)').matches)
       )
     }
 

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -23,7 +23,11 @@ export const CoreHelperUtil = {
 
   isMobile() {
     if (typeof window !== 'undefined') {
-      return this.isMobileDevice() || Boolean(window.matchMedia('(pointer:coarse)').matches)
+      return (
+        this.isInAppBrowser() ||
+        this.isMobileDevice() ||
+        Boolean(window.matchMedia('(pointer:coarse)').matches)
+      )
     }
 
     return false

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -5,7 +5,7 @@ import type { CaipAddress, LinkingRecord, CaipNetwork } from './TypeUtil.js'
 export const CoreHelperUtil = {
   isInAppBrowser() {
     if (typeof window !== 'undefined') {
-      return Boolean(/WebKit|wv|MetaMaskMobile|Phantom|/u.test(navigator.userAgent))
+      return Boolean(/WebKit|wv|MetaMaskMobile|Phantom/u.test(navigator.userAgent))
     }
 
     return false

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -5,7 +5,7 @@ import type { CaipAddress, LinkingRecord, CaipNetwork } from './TypeUtil.js'
 export const CoreHelperUtil = {
   isInAppBrowser() {
     if (typeof window !== 'undefined') {
-      return Boolean(/WebKit|(wv)|MetaMaskMobile|Phantom|/u.test(navigator.userAgent))
+      return Boolean(/WebKit|wv|MetaMaskMobile|Phantom|/u.test(navigator.userAgent))
     }
 
     return false

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -23,11 +23,7 @@ export const CoreHelperUtil = {
 
   isMobile() {
     if (typeof window !== 'undefined') {
-      return (
-        this.isInAppBrowser() ||
-        this.isMobileDevice() ||
-        Boolean(window.matchMedia('(pointer:coarse)').matches)
-      )
+      return this.isMobileDevice() || Boolean(window.matchMedia('(pointer:coarse)').matches)
     }
 
     return false

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -24,8 +24,13 @@ export const CoreHelperUtil = {
   isMobile() {
     if (typeof window !== 'undefined') {
       return (
-        this.isInAppBrowser() ||
-        this.isMobileDevice() ||
+        // In app browser
+        Boolean(/WebKit|wv|MetaMaskMobile|Phantom/u.test(navigator.userAgent)) ||
+        // Mobile device
+        Boolean(
+          /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
+        ) ||
+        // Touch screen
         Boolean(window.matchMedia('(pointer:coarse)').matches)
       )
     }


### PR DESCRIPTION
# Breaking Changes

Adde in-app browser checks to be sure that if the app is opened on any wallet's in-app browser, it should be detected as mobile as well
