### PR TITLE
fix: add 6492 verification  support to lab by using viem

### DIFF
--- a/apps/laboratory/src/pages/api/auth/[...nextauth].ts
+++ b/apps/laboratory/src/pages/api/auth/[...nextauth].ts
@@ -1,12 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import nextAuth from 'next-auth'
 import credentialsProvider from 'next-auth/providers/credentials'
-import {
-  type SIWESession,
-  verifySignature,
-  getChainIdFromMessage,
-  getAddressFromMessage
-} from '@web3modal/siwe'
+import { type SIWESession, getChainIdFromMessage, getAddressFromMessage } from '@web3modal/siwe'
+import { verifySignature } from '../../../utils/SignatureUtil'
 
 declare module 'next-auth' {
   interface Session extends SIWESession {
@@ -51,8 +47,12 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
           const { message, signature } = credentials
           const address = getAddressFromMessage(message)
           const chainId = getChainIdFromMessage(message)
-
-          const isValid = await verifySignature({ address, message, signature, chainId, projectId })
+          const isValid = await verifySignature({
+            address,
+            message,
+            signature,
+            chainId: Number(chainId.split(':')[1])
+          })
 
           if (isValid) {
             return {

--- a/apps/laboratory/src/utils/SignatureUtil.ts
+++ b/apps/laboratory/src/utils/SignatureUtil.ts
@@ -1,0 +1,31 @@
+import { createPublicClient, http } from 'viem'
+
+function getTransport({ chainId }: { chainId: number }) {
+  const RPC_URL = 'https://rpc.walletconnect.com'
+
+  return http(
+    `${RPC_URL}/v1/?chainId=eip155:${chainId}&projectId=${process.env['NEXT_PUBLIC_PROJECT_ID']}`
+  )
+}
+
+export async function verifySignature({
+  address,
+  message,
+  signature,
+  chainId
+}: {
+  address: string
+  message: string
+  signature: string
+  chainId: number
+}) {
+  const publicClient = createPublicClient({
+    transport: getTransport({ chainId })
+  })
+
+  return publicClient.verifyMessage({
+    message,
+    address: address as `0x${string}`,
+    signature: signature as `0x${string}`
+  })
+}

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -2,15 +2,7 @@ import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import { ConstantsUtil } from '../../../src/utils/ConstantsUtil'
 import { getMaximumWaitConnections } from '../utils/timeouts'
-import { createPublicClient, http } from 'viem'
-
-function getTransport({ chainId }: { chainId: number }) {
-  const RPC_URL = 'https://rpc.walletconnect.com'
-
-  return http(
-    `${RPC_URL}/v1/?chainId=eip155:${chainId}&projectId=${process.env['NEXT_PUBLIC_PROJECT_ID']}`
-  )
-}
+import { verifySignature } from '../../../src/utils/SignatureUtil'
 
 const MAX_WAIT = getMaximumWaitConnections()
 
@@ -102,13 +94,11 @@ export class ModalValidator {
   }
 
   async expectValidSignature(signature: `0x${string}`, address: `0x${string}`, chainId: number) {
-    const publicClient = createPublicClient({
-      transport: getTransport({ chainId })
-    })
-    const isVerified = await publicClient.verifyMessage({
-      message: 'Hello Web3Modal!',
+    const isVerified = await verifySignature({
       address,
-      signature
+      message: 'Hello Web3Modal!',
+      signature,
+      chainId
     })
 
     expect(isVerified).toBe(true)


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat: Adds 6492 signature verification to lab auth middleware by replacing SIWE package validator with a public rpc validate call via `viem`
- fix:
- chore:

# Associated Issues

Closes APKT-345
