### PR TITLE
fix: encodes all `personal_sign` messages to hex

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -33,7 +33,10 @@ import {
   formatUnits,
   JsonRpcSigner,
   BrowserProvider,
-  Contract
+  Contract,
+  hexlify,
+  toUtf8Bytes,
+  isHexString
 } from 'ethers'
 import {
   EthersConstantsUtil,
@@ -306,10 +309,10 @@ export class Web3Modal extends Web3ModalScaffold {
         if (!provider) {
           throw new Error('connectionControllerClient:signMessage - provider is undefined')
         }
-
+        const hexMessage = isHexString(message) ? message : hexlify(toUtf8Bytes(message))
         const signature = await provider.request({
           method: 'personal_sign',
-          params: [message, this.getAddress()]
+          params: [hexMessage, this.getAddress()]
         })
 
         return signature as `0x${string}`

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -278,10 +278,12 @@ export class Web3Modal extends Web3ModalScaffold {
         if (!provider) {
           throw new Error('connectionControllerClient:signMessage - provider is undefined')
         }
-
+        const hexMessage = utils.isHexString(message)
+          ? message
+          : utils.hexlify(utils.toUtf8Bytes(message))
         const signature = await provider.request({
           method: 'personal_sign',
-          params: [message, this.getAddress()]
+          params: [hexMessage, this.getAddress()]
         })
 
         return signature as `0x${string}`


### PR DESCRIPTION
web3modal/ethers & web3modal/ethers5 were sending `personal_sign` payloads as plain text instead of hex