### PR TITLE
fix: ethers email defaults mainnet

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -525,7 +525,10 @@ export class Web3Modal extends Web3ModalScaffold {
   }
 
   public getChainId() {
-    return EthersStoreUtil.state.chainId
+    const storeChainId = EthersStoreUtil.state.chainId
+    const networkControllerChainId = NetworkUtil.caipNetworkIdToNumber(this.getCaipNetwork()?.id)
+
+    return storeChainId ?? networkControllerChainId
   }
 
   public getIsConnected() {


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes

- feat:
- fix: ethers not using pre-selected network and defaulting to mainnet on email
- chore:

