### PR TITLE
fix: add extension for locale import from dayjs

### DIFF
--- a/packages/common/src/utils/DateUtil.ts
+++ b/packages/common/src/utils/DateUtil.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import englishLocale from 'dayjs/locale/en'
+import englishLocale from 'dayjs/locale/en.js'
 import relativeTime from 'dayjs/plugin/relativeTime.js'
 import updateLocale from 'dayjs/plugin/updateLocale.js'
 


### PR DESCRIPTION
# Changes

As we any other modules we are exporting, we need to add `.js` extension for one of the modules from `dayjs`.

