### PR TITLE
refactor: update profile name rendering logic

### DIFF
--- a/apps/gallery/stories/composites/wui-account-button.stories.ts
+++ b/apps/gallery/stories/composites/wui-account-button.stories.ts
@@ -14,7 +14,7 @@ export default {
     avatarSrc: avatarImageSrc,
     address,
     balance: '0.527 ETH',
-    profileName: 'enesozturk.eth',
+    profileName: 'johndoe.eth',
     charsStart: 4,
     charsEnd: 6
   },

--- a/apps/gallery/stories/composites/wui-account-button.stories.ts
+++ b/apps/gallery/stories/composites/wui-account-button.stories.ts
@@ -14,7 +14,7 @@ export default {
     avatarSrc: avatarImageSrc,
     address,
     balance: '0.527 ETH',
-    isProfileName: false,
+    profileName: 'enesozturk.eth',
     charsStart: 4,
     charsEnd: 6
   },
@@ -22,8 +22,8 @@ export default {
     disabled: {
       control: { type: 'boolean' }
     },
-    isProfileName: {
-      control: { type: 'boolean' }
+    profileName: {
+      control: { type: 'text' }
     }
   }
 } as Component
@@ -32,7 +32,7 @@ export const Default: Component = {
   render: args =>
     html`<wui-account-button
       ?disabled=${args.disabled}
-      ?isProfileName=${args.isProfileName}
+      profileName=${args.profileName}
       .networkSrc=${args.networkSrc}
       .avatarSrc=${args.avatarSrc}
       .balance=${args.balance}

--- a/apps/gallery/stories/composites/wui-profile-button.stories.ts
+++ b/apps/gallery/stories/composites/wui-profile-button.stories.ts
@@ -12,7 +12,7 @@ export default {
     networkSrc: networkImageSrc,
     avatarSrc: avatarImageSrc,
     address,
-    profileName: 'enesozturk.eth'
+    profileName: 'johndoe.eth'
   },
   argTypes: {
     profileName: {

--- a/apps/gallery/stories/composites/wui-profile-button.stories.ts
+++ b/apps/gallery/stories/composites/wui-profile-button.stories.ts
@@ -12,11 +12,11 @@ export default {
     networkSrc: networkImageSrc,
     avatarSrc: avatarImageSrc,
     address,
-    isProfileName: false
+    profileName: 'enesozturk.eth'
   },
   argTypes: {
-    isProfileName: {
-      control: { type: 'boolean' }
+    profileName: {
+      control: { type: 'text' }
     }
   }
 } as Component
@@ -24,7 +24,7 @@ export default {
 export const Default: Component = {
   render: args =>
     html`<wui-profile-button
-      ?isProfileName=${args.isProfileName}
+      profileName=${args.profileName}
       .networkSrc=${args.networkSrc}
       .avatarSrc=${args.avatarSrc}
       address=${args.address}

--- a/packages/scaffold/src/modal/w3m-account-button/index.ts
+++ b/packages/scaffold/src/modal/w3m-account-button/index.ts
@@ -81,7 +81,6 @@ export class W3mAccountButton extends LitElement {
         .isUnsupportedChain=${this.isUnsupportedChain}
         address=${ifDefined(this.address)}
         profileName=${ifDefined(this.profileName)}
-        ?isProfileName=${Boolean(this.profileName)}
         networkSrc=${ifDefined(networkImage)}
         avatarSrc=${ifDefined(this.profileImage)}
         balance=${showBalance

--- a/packages/scaffold/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -100,7 +100,7 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
         networkSrc=${ifDefined(networkImage)}
         icon="chevronBottom"
         avatarSrc=${ifDefined(this.profileImage ? this.profileImage : undefined)}
-        ?isprofilename=${Boolean(this.profileName)}
+        profileName=${this.profileName}
       ></wui-profile-button>
       ${this.tokenBalanceTemplate()}
       <wui-flex gap="s">

--- a/packages/ui/src/composites/wui-account-button/index.ts
+++ b/packages/ui/src/composites/wui-account-button/index.ts
@@ -26,8 +26,6 @@ export class WuiAccountButton extends LitElement {
 
   @property({ type: Boolean }) public disabled = false
 
-  @property({ type: Boolean }) public isProfileName = false
-
   @property() public address = ''
 
   @property() public profileName = ''
@@ -53,10 +51,10 @@ export class WuiAccountButton extends LitElement {
           <wui-text variant="paragraph-600" color="inherit">
             ${this.address
               ? UiHelperUtil.getTruncateString({
-                  string: this.isProfileName ? this.profileName : this.address,
-                  charsStart: this.isProfileName ? 18 : this.charsStart,
-                  charsEnd: this.isProfileName ? 0 : this.charsEnd,
-                  truncate: this.isProfileName ? 'end' : 'middle'
+                  string: this.profileName || this.address,
+                  charsStart: this.profileName ? 18 : this.charsStart,
+                  charsEnd: this.profileName ? 0 : this.charsEnd,
+                  truncate: this.profileName ? 'end' : 'middle'
                 })
               : null}
           </wui-text>

--- a/packages/ui/src/composites/wui-profile-button/index.ts
+++ b/packages/ui/src/composites/wui-profile-button/index.ts
@@ -21,7 +21,7 @@ export class WuiProfileButton extends LitElement {
 
   @property() public avatarSrc?: string = undefined
 
-  @property({ type: Boolean }) public isProfileName = false
+  @property() public profileName?: string = ''
 
   @property() public address = ''
 
@@ -40,10 +40,10 @@ export class WuiProfileButton extends LitElement {
         <wui-flex gap="xs" alignItems="center">
           <wui-text variant="large-600" color="fg-100">
             ${UiHelperUtil.getTruncateString({
-              string: this.address,
-              charsStart: this.isProfileName ? 18 : 4,
-              charsEnd: this.isProfileName ? 0 : 4,
-              truncate: this.isProfileName ? 'end' : 'middle'
+              string: this.profileName || this.address,
+              charsStart: this.profileName ? 18 : 4,
+              charsEnd: this.profileName ? 0 : 4,
+              truncate: this.profileName ? 'end' : 'middle'
             })}
           </wui-text>
           <wui-icon size="sm" color="fg-200" name=${this.icon}></wui-icon>


### PR DESCRIPTION
# Changes

When we have profile name, the `wui-account-button` makes conditional truncating by `isProfileButton` but it's not rendering the name properly. This PR introduces refactors to `wui-profile-button` and `wui-account-button` components to render profile name if it exists and make required truncating 
