### PR TITLE
fix: renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,22 +9,22 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["*"],
+      "matchPackagePatterns": ["*"],
       "enabled": false
     },
     {
       "matchPackageNames": [
         "@walletconnect/utils",
-        "@web3modal/*",
         "wagmi",
         "@wagmi/connectors",
         "viem",
         "ethers",
         "@solana/web3.js"
       ],
+      "matchPackagePrefixes": ["@web3modal/"],
       "enabled": true,
       "prPriority": 10
     }
   ],
-  "includePaths": ["apps/laboratory"]
+  "includePaths": ["apps/laboratory/package.json"]
 }


### PR DESCRIPTION
Fixes several issues with the config, based on my reviewing of the docs:
- `includePaths` must be a pattern matching package manager files (e.g. package.json), not a prefix
- `matchPackageNames` does not support wildcards