### PR TITLE
fixed: solflare network mismatch

### DIFF
--- a/packages/solana/src/client.ts
+++ b/packages/solana/src/client.ts
@@ -196,7 +196,7 @@ export class Web3Modal extends Web3ModalScaffold {
     }
     this.syncNetwork(chainImages)
 
-    this.walletAdapters = createWalletAdapters()
+    this.walletAdapters = createWalletAdapters(options.defaultChain)
     this.WalletConnectConnector = new WalletConnectConnector({
       relayerRegion: 'wss://relay.walletconnect.com',
       metadata,

--- a/packages/solana/src/connectors/walletAdapters.ts
+++ b/packages/solana/src/connectors/walletAdapters.ts
@@ -5,18 +5,28 @@ import {
   TrustWalletAdapter
 } from './walletAdapters/index.js'
 
-import type { BaseWalletAdapter } from '@solana/wallet-adapter-base'
 import type { Connector } from '@web3modal/scaffold'
+import type { Chain } from '../utils/scaffold/SolanaTypesUtil.js'
+import { solana, solanaDevnet, solanaTestnet } from '../utils/chains.js'
+import { WalletAdapterNetwork, type BaseWalletAdapter } from '@solana/wallet-adapter-base'
 
 export type AdapterKey = 'phantom' | 'solflare' | 'trustWallet' | 'backpack'
 export const supportedWallets: AdapterKey[] = ['phantom', 'solflare', 'trustWallet', 'backpack']
 
-export function createWalletAdapters() {
+const chainMap = {
+  [solana.chainId]: WalletAdapterNetwork.Mainnet,
+  [solanaDevnet.chainId]: WalletAdapterNetwork.Devnet,
+  [solanaTestnet.chainId]: WalletAdapterNetwork.Testnet
+}
+
+export function createWalletAdapters(chain?: Chain) {
   return {
     phantom: new PhantomWalletAdapter(),
     trustWallet: new TrustWalletAdapter(),
     backpack: new BackpackWalletAdapter(),
-    solflare: new SolflareWalletAdapter()
+    solflare: new SolflareWalletAdapter({
+      network: chainMap[chain?.chainId || solana.chainId]
+    })
   }
 }
 


### PR DESCRIPTION
# Breaking Changes

The necessary parameter was sent to the Solflare adapter that needs the network value with a mapping suitable for the network structure in Web3Modal and the network structure in Solana Wallet Adapter packages. Thus, the network mismatch problem was solved.

# Changes

- feat: Solana packages
- fix: Solflare network mismatch
- chore: No

# Associated Issues

closes #...
