### PR TITLE
chore: update siwe action button props

### DIFF
--- a/packages/siwe/scaffold/views/w3m-connecting-siwe-view/index.ts
+++ b/packages/siwe/scaffold/views/w3m-connecting-siwe-view/index.ts
@@ -49,7 +49,8 @@ export class W3mConnectingSiweView extends LitElement {
       </wui-flex>
       <wui-flex .padding=${['l', 'xl', 'xl', 'xl'] as const} gap="s" justifyContent="space-between">
         <wui-button
-          size="md"
+          size="lg"
+          borderRadius="xs"
           fullWidth
           variant="neutral"
           @click=${this.onCancel.bind(this)}
@@ -58,7 +59,8 @@ export class W3mConnectingSiweView extends LitElement {
           Cancel
         </wui-button>
         <wui-button
-          size="md"
+          size="lg"
+          borderRadius="xs"
           fullWidth
           variant="main"
           @click=${this.onSign.bind(this)}


### PR DESCRIPTION
# Breaking Changes

SIWE modal have old version of styles. Size and border radius props needs to be updated.

# Screenshots

| Column 1 Header | Column 2 Header |
|-----------------|-----------------|
| <img width="200" alt="Screenshot 2024-05-28 at 11 02 45" src="https://github.com/WalletConnect/web3modal/assets/19428358/31b8ba93-997f-48fd-9c8b-95ebdcbdcef7">  | <img width="200" alt="Screenshot 2024-05-28 at 11 06 53" src="https://github.com/WalletConnect/web3modal/assets/19428358/0bb63adc-64f2-42b8-a833-a934e2300ad0">  |



