### PR TITLE
fix: coinbase connector issues

### DIFF
--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -1385,10 +1385,10 @@ export class Web3Modal extends Web3ModalScaffold {
     if (config.coinbase) {
       w3mConnectors.push({
         id: ConstantsUtil.COINBASE_SDK_CONNECTOR_ID,
-        explorerId: PresetsUtil.ConnectorExplorerIds[ConstantsUtil.COINBASE_CONNECTOR_ID],
-        imageId: PresetsUtil.ConnectorImageIds[ConstantsUtil.COINBASE_CONNECTOR_ID],
-        imageUrl: this.options?.connectorImages?.[ConstantsUtil.COINBASE_CONNECTOR_ID],
-        name: PresetsUtil.ConnectorNamesMap[ConstantsUtil.COINBASE_CONNECTOR_ID],
+        explorerId: PresetsUtil.ConnectorExplorerIds[ConstantsUtil.COINBASE_SDK_CONNECTOR_ID],
+        imageId: PresetsUtil.ConnectorImageIds[ConstantsUtil.COINBASE_SDK_CONNECTOR_ID],
+        imageUrl: this.options?.connectorImages?.[ConstantsUtil.COINBASE_SDK_CONNECTOR_ID],
+        name: PresetsUtil.ConnectorNamesMap[ConstantsUtil.COINBASE_SDK_CONNECTOR_ID],
         type: 'EXTERNAL'
       })
     }
@@ -1431,8 +1431,15 @@ export class Web3Modal extends Web3ModalScaffold {
       const { info, provider } = event.detail
       const connectors = this.getConnectors()
       const existingConnector = connectors.find(c => c.name === info.name)
+      const coinbaseConnector = connectors.find(
+        c => c.id === ConstantsUtil.COINBASE_SDK_CONNECTOR_ID
+      )
+      const isCoinbaseDuplicated =
+        coinbaseConnector &&
+        event.detail.info.rdns ===
+          ConstantsUtil.CONNECTOR_RDNS_MAP[ConstantsUtil.COINBASE_CONNECTOR_ID]
 
-      if (!existingConnector) {
+      if (!existingConnector && !isCoinbaseDuplicated) {
         const type = PresetsUtil.ConnectorTypesMap[ConstantsUtil.EIP6963_CONNECTOR_ID]
         if (type) {
           this.addConnector({

--- a/packages/scaffold-utils/src/PresetsUtil.ts
+++ b/packages/scaffold-utils/src/PresetsUtil.ts
@@ -5,6 +5,8 @@ export const PresetsUtil = {
   ConnectorExplorerIds: {
     [ConstantsUtil.COINBASE_CONNECTOR_ID]:
       'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa',
+    [ConstantsUtil.COINBASE_SDK_CONNECTOR_ID]:
+      'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa',
     [ConstantsUtil.SAFE_CONNECTOR_ID]:
       '225affb176778569276e484e1b92637ad061b01e13a048b35a9d280c3b58970f',
     [ConstantsUtil.LEDGER_CONNECTOR_ID]:


### PR DESCRIPTION
# Breaking Changes

N/A

## Summary
When Coinbase Wallet extension is installed, Coinbase shows up twice in ethers.
Also, wagmi did not trigger connection flow when clicking on Coinbase connector from the "All wallets" list. 

- feat:
- fix: filter cb connector on ethers. Add explorer ID for coinbase sdk connector
- chore:

