### PR TITLE
chore: fix renovate matchFileNames

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,8 @@
       "enabled": false
     },
     {
+      "matchFileNames": ["apps/laboratory/package.json"],
+      "enabled": true,
       "matchPackageNames": [
         "@walletconnect/utils",
         "wagmi",
@@ -22,9 +24,7 @@
         "@solana/web3.js"
       ],
       "matchPackagePrefixes": ["@web3modal/"],
-      "enabled": true,
       "prPriority": 10
     }
-  ],
-  "includePaths": ["apps/laboratory/package.json"]
+  ]
 }


### PR DESCRIPTION
# Changes

- chore: fix renovate config to use matchFileNames

# Notes

This configuration was tested [here](https://github.com/chris13524/web3modal/pulls)