### PR TITLE
refactor: update scroll lock stylings

### DIFF
--- a/packages/scaffold/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold/src/modal/w3m-modal/index.ts
@@ -120,7 +120,7 @@ export class W3mModal extends LitElement {
     const styleTag = document.createElement('style')
     styleTag.dataset['w3m'] = SCROLL_LOCK
     styleTag.textContent = `
-      html, body {
+      body {
         touch-action: none;
         overflow: hidden;
         overscroll-behavior: contain;


### PR DESCRIPTION
# Changes

When we open the modal, we are disabling scroll and pointer events for both `html` and `body`. This causing some issues if you use absolute or sticky styling in one of the elements under the `body` tag. 

See examples: 
- Wagmi website: https://1.x.wagmi.sh/examples/connect-wallet
- Go to link
- Select WalletConnect modal
- See the layout is shifting

Most of the primitive UI libraries (like [Radix](https://www.radix-ui.com/primitives/docs/components/dialog#dialog)) 
 locking only `body`, not `html`. When building web page, it's generally an anti-pattern to override `html` tag's overflow or positioning props. So our modal should follow the same pattern and let users have sticky positioned elements work better along with web3modal.


# Associated Issues

- fixes https://github.com/WalletConnect/web3modal/issues/1060
- [Slack thread](https://walletconnect.slack.com/archives/C03RU4F6P8A/p1717629059192329)
