### PR TITLE
fix: wagmiconfig being created twice causeing multiple relay requests

### DIFF
--- a/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
@@ -9,8 +9,8 @@ export function WagmiModalInfo() {
   const [clientId, setClientId] = React.useState<string | null>(null)
 
   async function getClientId() {
-    const provider = await connector?.getProvider()
     if (connector?.type === 'walletConnect') {
+      const provider = await connector?.getProvider()
       const ethereumProvider = provider as EthereumProvider
 
       return ethereumProvider?.signer?.client?.core?.crypto?.getClientId()

--- a/apps/laboratory/src/pages/library/wagmi-all.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-all.tsx
@@ -5,7 +5,7 @@ import { WagmiProvider } from 'wagmi'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
-import { CONFIGS } from '../../utils/WagmiConstants'
+import { getWagmiConfig } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { SiweData } from '../../components/Siwe/SiweData'
 import { siweConfig } from '../../utils/SiweUtils'
@@ -13,7 +13,7 @@ import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
-const wagmiConfig = CONFIGS.email
+const wagmiConfig = getWagmiConfig('email')
 const modal = createWeb3Modal({
   wagmiConfig,
   projectId: ConstantsUtil.ProjectId,

--- a/apps/laboratory/src/pages/library/wagmi-email.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-email.tsx
@@ -7,11 +7,11 @@ import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
-import { CONFIGS } from '../../utils/WagmiConstants'
+import { getWagmiConfig } from '../../utils/WagmiConstants'
 
 const queryClient = new QueryClient()
 
-const wagmiConfig = CONFIGS.email
+const wagmiConfig = getWagmiConfig('email')
 const modal = createWeb3Modal({
   wagmiConfig,
   projectId: ConstantsUtil.ProjectId,

--- a/apps/laboratory/src/pages/library/wagmi-siwe.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-siwe.tsx
@@ -4,7 +4,7 @@ import { WagmiProvider } from 'wagmi'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
-import { CONFIGS } from '../../utils/WagmiConstants'
+import { getWagmiConfig } from '../../utils/WagmiConstants'
 import { SiweData } from '../../components/Siwe/SiweData'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { siweConfig } from '../../utils/SiweUtils'
@@ -12,7 +12,7 @@ import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
-const wagmiConfig = CONFIGS.default
+const wagmiConfig = getWagmiConfig('default')
 const modal = createWeb3Modal({
   wagmiConfig,
   projectId: ConstantsUtil.ProjectId,

--- a/apps/laboratory/src/pages/library/wagmi-wallet.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-wallet.tsx
@@ -5,13 +5,13 @@ import { WagmiProvider } from 'wagmi'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
-import { CONFIGS } from '../../utils/WagmiConstants'
+import { getWagmiConfig } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
-const wagmiConfig = CONFIGS.email
+const wagmiConfig = getWagmiConfig('email')
 
 const modal = createWeb3Modal({
   wagmiConfig,

--- a/apps/laboratory/src/pages/library/wagmi.tsx
+++ b/apps/laboratory/src/pages/library/wagmi.tsx
@@ -4,13 +4,13 @@ import { WagmiProvider } from 'wagmi'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
-import { CONFIGS } from '../../utils/WagmiConstants'
+import { getWagmiConfig } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
 
 const queryClient = new QueryClient()
 
-const wagmiConfig = CONFIGS.default
+const wagmiConfig = getWagmiConfig('default')
 
 const modal = createWeb3Modal({
   wagmiConfig,

--- a/apps/laboratory/src/utils/WagmiConstants.ts
+++ b/apps/laboratory/src/utils/WagmiConstants.ts
@@ -39,20 +39,22 @@ export const WagmiConstantsUtil = {
   ] as [Chain, ...Chain[]]
 }
 
-export const CONFIGS = {
-  default: defaultWagmiConfig({
+export function getWagmiConfig(type: 'default' | 'email') {
+  const config = {
     chains: WagmiConstantsUtil.chains,
     projectId: ConstantsUtil.ProjectId,
     metadata: ConstantsUtil.Metadata,
     ssr: true
-  }),
-  email: defaultWagmiConfig({
-    chains: WagmiConstantsUtil.chains,
-    projectId: ConstantsUtil.ProjectId,
-    metadata: ConstantsUtil.Metadata,
+  }
+
+  const emailConfig = {
+    ...config,
     auth: {
       socials: ['google', 'x', 'discord', 'apple', 'github']
-    },
-    ssr: true
-  })
+    }
+  }
+
+  const wagmiConfig = defaultWagmiConfig(type === 'email' ? emailConfig : config)
+
+  return wagmiConfig
 }


### PR DESCRIPTION
# Breaking Changes

N/A

# Changes
Relay connections were being established twice because we were initializing an instance of wagmi config for email and another for default.
Change the way we structure our default configs so that `createDefaultWagmiConfig` is called a single time, instantiating connectors a single time. 
