### PR TITLE
chore(renovate): only auto rebase renovate PRs when conflicted

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ":semanticCommits",
     ":semanticCommitScope(deps)"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
## Context

- Renovatebot will by default auto rebase all open renovate PRs when the base branch is updated.
- This is causing Vercel build cascades that cause long queue times unnecessarily for more important builds.
- We already use this rule here: https://github.com/WalletConnect/web-examples/blob/main/renovate.json#L10