### PR TITLE
fix: close modal if no need to reauth

### DIFF
--- a/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
@@ -10,7 +10,7 @@ export function WagmiModalInfo() {
 
   async function getClientId() {
     if (connector?.type === 'walletConnect') {
-      const provider = await connector?.getProvider()
+      const provider = await connector?.getProvider?.()
       const ethereumProvider = provider as EthereumProvider
 
       return ethereumProvider?.signer?.client?.core?.crypto?.getClientId()

--- a/apps/laboratory/tests/siwe.spec.ts
+++ b/apps/laboratory/tests/siwe.spec.ts
@@ -10,28 +10,28 @@ testMWSiwe.afterEach(async ({ modalValidator, walletValidator, browserName }) =>
   await walletValidator.expectDisconnected()
 })
 
-// testMWSiwe(
-//   'it should sign in with ethereum',
-//   async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
-//     const uri = await modalPage.getConnectUri()
-//     await walletPage.connectWithUri(uri)
-//     await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
-//     await modalValidator.expectAuthenticated()
-//     await modalValidator.expectConnected()
-//     await walletValidator.expectConnected()
-//     await modalPage.disconnect()
-//   }
-// )
+testMWSiwe(
+  'it should sign in with ethereum',
+  async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+    const uri = await modalPage.getConnectUri()
+    await walletPage.connectWithUri(uri)
+    await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
+    await modalValidator.expectAuthenticated()
+    await modalValidator.expectConnected()
+    await walletValidator.expectConnected()
+    await modalPage.disconnect()
+  }
+)
 
-// testMWSiwe(
-//   'it should reject sign in with ethereum',
-//   async ({ modalPage, walletPage, modalValidator }) => {
-//     const uri = await modalPage.getConnectUri()
-//     await walletPage.connectWithUri(uri)
-//     await walletPage.handleRequest({ accept: false })
-//     await modalValidator.expectUnauthenticated()
-//   }
-// )
+testMWSiwe(
+  'it should reject sign in with ethereum',
+  async ({ modalPage, walletPage, modalValidator }) => {
+    const uri = await modalPage.getConnectUri()
+    await walletPage.connectWithUri(uri)
+    await walletPage.handleRequest({ accept: false })
+    await modalValidator.expectUnauthenticated()
+  }
+)
 
 testMWSiwe(
   'it should require re-authentication when switching networks',
@@ -46,10 +46,7 @@ testMWSiwe(
 
     // Re-authentication required
     await modalValidator.expectUnauthenticated()
-    await modalPage.promptSiwe()
-    await walletPage.handleRequest({ accept: true })
-    await modalValidator.expectAuthenticated()
     await modalPage.closeModal()
-    await modalPage.disconnect()
+    await modalValidator.expectDisconnected()
   }
 )

--- a/apps/laboratory/tests/siwe.spec.ts
+++ b/apps/laboratory/tests/siwe.spec.ts
@@ -10,8 +10,31 @@ testMWSiwe.afterEach(async ({ modalValidator, walletValidator, browserName }) =>
   await walletValidator.expectDisconnected()
 })
 
+// testMWSiwe(
+//   'it should sign in with ethereum',
+//   async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
+//     const uri = await modalPage.getConnectUri()
+//     await walletPage.connectWithUri(uri)
+//     await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
+//     await modalValidator.expectAuthenticated()
+//     await modalValidator.expectConnected()
+//     await walletValidator.expectConnected()
+//     await modalPage.disconnect()
+//   }
+// )
+
+// testMWSiwe(
+//   'it should reject sign in with ethereum',
+//   async ({ modalPage, walletPage, modalValidator }) => {
+//     const uri = await modalPage.getConnectUri()
+//     await walletPage.connectWithUri(uri)
+//     await walletPage.handleRequest({ accept: false })
+//     await modalValidator.expectUnauthenticated()
+//   }
+// )
+
 testMWSiwe(
-  'it should sign in with ethereum',
+  'it should require re-authentication when switching networks',
   async ({ modalPage, walletPage, modalValidator, walletValidator }) => {
     const uri = await modalPage.getConnectUri()
     await walletPage.connectWithUri(uri)
@@ -19,16 +42,14 @@ testMWSiwe(
     await modalValidator.expectAuthenticated()
     await modalValidator.expectConnected()
     await walletValidator.expectConnected()
-    await modalPage.disconnect()
-  }
-)
+    await modalPage.switchNetwork('Polygon')
 
-testMWSiwe(
-  'it should reject sign in with ethereum',
-  async ({ modalPage, walletPage, modalValidator }) => {
-    const uri = await modalPage.getConnectUri()
-    await walletPage.connectWithUri(uri)
-    await walletPage.handleRequest({ accept: false })
+    // Re-authentication required
     await modalValidator.expectUnauthenticated()
+    await modalPage.promptSiwe()
+    await walletPage.handleRequest({ accept: true })
+    await modalValidator.expectAuthenticated()
+    await modalPage.closeModal()
+    await modalPage.disconnect()
   }
 )

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -6,6 +6,8 @@ import { EventsController } from './EventsController.js'
 import { ModalController } from './ModalController.js'
 import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { NetworkUtil } from '@web3modal/common'
+import { OptionsController } from './OptionsController.js'
+import { RouterUtil } from '../utils/RouterUtil.js'
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
@@ -106,6 +108,14 @@ export const NetworkController = {
 
   async switchActiveNetwork(network: NetworkControllerState['caipNetwork']) {
     await this._getClient().switchCaipNetwork(network)
+    if (OptionsController.state.isSiweEnabled) {
+      const { SIWEController } = await import('@web3modal/siwe')
+      if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+        await SIWEController.signOut()
+      }
+    } else {
+      RouterUtil.navigateAfterNetworkSwitch()
+    }
 
     state.caipNetwork = network
     if (network) {

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -6,8 +6,6 @@ import { EventsController } from './EventsController.js'
 import { ModalController } from './ModalController.js'
 import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { NetworkUtil } from '@web3modal/common'
-import { OptionsController } from './OptionsController.js'
-import { RouterUtil } from '../utils/RouterUtil.js'
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
@@ -108,15 +106,6 @@ export const NetworkController = {
 
   async switchActiveNetwork(network: NetworkControllerState['caipNetwork']) {
     await this._getClient().switchCaipNetwork(network)
-    if (OptionsController.state.isSiweEnabled) {
-      const { SIWEController } = await import('@web3modal/siwe')
-      if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
-        await SIWEController.signOut()
-      }
-    } else {
-      RouterUtil.navigateAfterNetworkSwitch()
-    }
-
     state.caipNetwork = network
     if (network) {
       EventsController.sendEvent({

--- a/packages/scaffold/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold/src/modal/w3m-modal/index.ts
@@ -171,6 +171,8 @@ export class W3mModal extends LitElement {
 
     const previousAddress = CoreHelperUtil.getPlainAddress(this.caipAddress)
     const newAddress = CoreHelperUtil.getPlainAddress(caipAddress)
+    const previousNetworkId = CoreHelperUtil.getNetworkId(this.caipAddress)
+    const newNetworkId = CoreHelperUtil.getNetworkId(caipAddress)
     this.caipAddress = caipAddress
 
     if (this.isSiweEnabled) {
@@ -180,6 +182,19 @@ export class W3mModal extends LitElement {
       // If the address has changed and signOnAccountChange is enabled, sign out
       if (session && previousAddress && newAddress && previousAddress !== newAddress) {
         if (SIWEController.state._client?.options.signOutOnAccountChange) {
+          await SIWEController.signOut()
+          this.onSiweNavigation()
+        }
+
+        return
+      }
+
+      /*
+       * If the network has changed and signOnNetworkChange is enabled, sign out
+       * Covers case where network is switched wallet-side
+       */
+      if (session && previousNetworkId && newNetworkId && previousNetworkId !== newNetworkId) {
+        if (SIWEController.state._client?.options.signOutOnNetworkChange) {
           await SIWEController.signOut()
           this.onSiweNavigation()
         }

--- a/packages/scaffold/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold/src/modal/w3m-modal/index.ts
@@ -171,8 +171,6 @@ export class W3mModal extends LitElement {
 
     const previousAddress = CoreHelperUtil.getPlainAddress(this.caipAddress)
     const newAddress = CoreHelperUtil.getPlainAddress(caipAddress)
-    const previousNetworkId = CoreHelperUtil.getNetworkId(this.caipAddress)
-    const newNetworkId = CoreHelperUtil.getNetworkId(caipAddress)
     this.caipAddress = caipAddress
 
     if (this.isSiweEnabled) {
@@ -182,16 +180,6 @@ export class W3mModal extends LitElement {
       // If the address has changed and signOnAccountChange is enabled, sign out
       if (session && previousAddress && newAddress && previousAddress !== newAddress) {
         if (SIWEController.state._client?.options.signOutOnAccountChange) {
-          await SIWEController.signOut()
-          this.onSiweNavigation()
-        }
-
-        return
-      }
-
-      // If the network has changed and signOnNetworkChange is enabled, sign out
-      if (session && previousNetworkId && newNetworkId && previousNetworkId !== newNetworkId) {
-        if (SIWEController.state._client?.options.signOutOnNetworkChange) {
           await SIWEController.signOut()
           this.onSiweNavigation()
         }

--- a/packages/scaffold/src/utils/NetworkUtil.ts
+++ b/packages/scaffold/src/utils/NetworkUtil.ts
@@ -1,0 +1,14 @@
+import { OptionsController, RouterUtil } from '@web3modal/core'
+
+export const NetworkUtil = {
+  onNetworkChange: async () => {
+    const { SIWEController } = await import('@web3modal/siwe')
+    if (OptionsController.state.isSiweEnabled) {
+      if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+        await SIWEController.signOut()
+      }
+    } else {
+      RouterUtil.navigateAfterNetworkSwitch()
+    }
+  }
+}

--- a/packages/scaffold/src/utils/NetworkUtil.ts
+++ b/packages/scaffold/src/utils/NetworkUtil.ts
@@ -6,6 +6,8 @@ export const NetworkUtil = {
       const { SIWEController } = await import('@web3modal/siwe')
       if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
         await SIWEController.signOut()
+      } else {
+        RouterUtil.navigateAfterNetworkSwitch()
       }
     } else {
       RouterUtil.navigateAfterNetworkSwitch()

--- a/packages/scaffold/src/utils/NetworkUtil.ts
+++ b/packages/scaffold/src/utils/NetworkUtil.ts
@@ -2,8 +2,8 @@ import { OptionsController, RouterUtil } from '@web3modal/core'
 
 export const NetworkUtil = {
   onNetworkChange: async () => {
-    const { SIWEController } = await import('@web3modal/siwe')
     if (OptionsController.state.isSiweEnabled) {
+      const { SIWEController } = await import('@web3modal/siwe')
       if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
         await SIWEController.signOut()
       }

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -12,6 +12,7 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import styles from './styles.js'
+import { SIWEController } from '@web3modal/siwe'
 
 @customElement('w3m-network-switch-view')
 export class W3mNetworkSwitchView extends LitElement {
@@ -134,7 +135,10 @@ export class W3mNetworkSwitchView extends LitElement {
       this.error = false
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
-        if (!OptionsController.state.isSiweEnabled) {
+        if (
+          !OptionsController.state.isSiweEnabled ||
+          !SIWEController.state._client?.options?.signOutOnNetworkChange
+        ) {
           RouterUtil.navigateAfterNetworkSwitch()
         }
       }

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -136,9 +136,11 @@ export class W3mNetworkSwitchView extends LitElement {
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
         if (
-          !OptionsController.state.isSiweEnabled ||
-          !SIWEController.state._client?.options?.signOutOnNetworkChange
+          OptionsController.state.isSiweEnabled &&
+          SIWEController.state._client?.options?.signOutOnNetworkChange
         ) {
+          await SIWEController.signOut()
+        } else {
           RouterUtil.navigateAfterNetworkSwitch()
         }
       }

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -2,9 +2,7 @@ import {
   AssetUtil,
   ConnectorController,
   NetworkController,
-  OptionsController,
   RouterController,
-  RouterUtil,
   StorageUtil
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
@@ -41,6 +39,7 @@ export class W3mNetworkSwitchView extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
+    console.log('SWITCH NETWORK VIEW')
     if (!this.network) {
       throw new Error('w3m-network-switch-view: No network provided')
     }
@@ -134,14 +133,6 @@ export class W3mNetworkSwitchView extends LitElement {
       this.error = false
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
-        if (OptionsController.state.isSiweEnabled) {
-          const { SIWEController } = await import('@web3modal/siwe')
-          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
-            await SIWEController.signOut()
-          }
-        } else {
-          RouterUtil.navigateAfterNetworkSwitch()
-        }
       }
     } catch {
       this.error = true

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -2,9 +2,7 @@ import {
   AssetUtil,
   ConnectorController,
   NetworkController,
-  OptionsController,
   RouterController,
-  RouterUtil,
   StorageUtil
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
@@ -12,6 +10,7 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import styles from './styles.js'
+import { NetworkUtil } from '../../utils/NetworkUtil.js'
 
 @customElement('w3m-network-switch-view')
 export class W3mNetworkSwitchView extends LitElement {
@@ -134,14 +133,7 @@ export class W3mNetworkSwitchView extends LitElement {
       this.error = false
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
-        if (OptionsController.state.isSiweEnabled) {
-          const { SIWEController } = await import('@web3modal/siwe')
-          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
-            await SIWEController.signOut()
-          }
-        } else {
-          RouterUtil.navigateAfterNetworkSwitch()
-        }
+        await NetworkUtil.onNetworkChange()
       }
     } catch {
       this.error = true

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -12,7 +12,6 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import styles from './styles.js'
-import { SIWEController } from '@web3modal/siwe'
 
 @customElement('w3m-network-switch-view')
 export class W3mNetworkSwitchView extends LitElement {
@@ -135,11 +134,11 @@ export class W3mNetworkSwitchView extends LitElement {
       this.error = false
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
-        if (
-          OptionsController.state.isSiweEnabled &&
-          SIWEController.state._client?.options?.signOutOnNetworkChange
-        ) {
-          await SIWEController.signOut()
+        if (OptionsController.state.isSiweEnabled) {
+          const { SIWEController } = await import('@web3modal/siwe')
+          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+            await SIWEController.signOut()
+          }
         } else {
           RouterUtil.navigateAfterNetworkSwitch()
         }

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.ts
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.ts
@@ -2,7 +2,9 @@ import {
   AssetUtil,
   ConnectorController,
   NetworkController,
+  OptionsController,
   RouterController,
+  RouterUtil,
   StorageUtil
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
@@ -39,7 +41,6 @@ export class W3mNetworkSwitchView extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    console.log('SWITCH NETWORK VIEW')
     if (!this.network) {
       throw new Error('w3m-network-switch-view: No network provided')
     }
@@ -133,6 +134,14 @@ export class W3mNetworkSwitchView extends LitElement {
       this.error = false
       if (this.network) {
         await NetworkController.switchActiveNetwork(this.network)
+        if (OptionsController.state.isSiweEnabled) {
+          const { SIWEController } = await import('@web3modal/siwe')
+          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+            await SIWEController.signOut()
+          }
+        } else {
+          RouterUtil.navigateAfterNetworkSwitch()
+        }
       }
     } catch {
       this.error = true

--- a/packages/scaffold/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold/src/views/w3m-networks-view/index.ts
@@ -5,7 +5,9 @@ import {
   CoreHelperUtil,
   EventsController,
   NetworkController,
-  RouterController
+  OptionsController,
+  RouterController,
+  RouterUtil
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
@@ -91,6 +93,14 @@ export class W3mNetworksView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
+        if (OptionsController.state.isSiweEnabled) {
+          const { SIWEController } = await import('@web3modal/siwe')
+          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+            await SIWEController.signOut()
+          }
+        } else {
+          RouterUtil.navigateAfterNetworkSwitch()
+        }
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/scaffold/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold/src/views/w3m-networks-view/index.ts
@@ -5,8 +5,7 @@ import {
   CoreHelperUtil,
   EventsController,
   NetworkController,
-  RouterController,
-  RouterUtil
+  RouterController
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
@@ -92,7 +91,6 @@ export class W3mNetworksView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
-        RouterUtil.navigateAfterNetworkSwitch()
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/scaffold/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold/src/views/w3m-networks-view/index.ts
@@ -5,15 +5,14 @@ import {
   CoreHelperUtil,
   EventsController,
   NetworkController,
-  OptionsController,
-  RouterController,
-  RouterUtil
+  RouterController
 } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import styles from './styles.js'
+import { NetworkUtil } from '../../utils/NetworkUtil.js'
 
 @customElement('w3m-networks-view')
 export class W3mNetworksView extends LitElement {
@@ -93,14 +92,7 @@ export class W3mNetworksView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
-        if (OptionsController.state.isSiweEnabled) {
-          const { SIWEController } = await import('@web3modal/siwe')
-          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
-            await SIWEController.signOut()
-          }
-        } else {
-          RouterUtil.navigateAfterNetworkSwitch()
-        }
+        await NetworkUtil.onNetworkChange()
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
+++ b/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
@@ -8,7 +8,6 @@ import {
   ModalController,
   NetworkController,
   RouterController,
-  RouterUtil,
   SnackController
 } from '@web3modal/core'
 
@@ -132,7 +131,6 @@ export class W3mUnsupportedChainView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
-        RouterUtil.navigateAfterNetworkSwitch()
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
+++ b/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
@@ -7,7 +7,9 @@ import {
   EventsController,
   ModalController,
   NetworkController,
+  OptionsController,
   RouterController,
+  RouterUtil,
   SnackController
 } from '@web3modal/core'
 
@@ -131,6 +133,14 @@ export class W3mUnsupportedChainView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
+        if (OptionsController.state.isSiweEnabled) {
+          const { SIWEController } = await import('@web3modal/siwe')
+          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
+            await SIWEController.signOut()
+          }
+        } else {
+          RouterUtil.navigateAfterNetworkSwitch()
+        }
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
+++ b/packages/scaffold/src/views/w3m-unsupported-chain-view/index.ts
@@ -7,9 +7,7 @@ import {
   EventsController,
   ModalController,
   NetworkController,
-  OptionsController,
   RouterController,
-  RouterUtil,
   SnackController
 } from '@web3modal/core'
 
@@ -19,6 +17,7 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import styles from './styles.js'
+import { NetworkUtil } from '../../utils/NetworkUtil.js'
 
 @customElement('w3m-unsupported-chain-view')
 export class W3mUnsupportedChainView extends LitElement {
@@ -133,14 +132,7 @@ export class W3mUnsupportedChainView extends LitElement {
     if (isConnected && caipNetwork?.id !== network.id) {
       if (approvedCaipNetworkIds?.includes(network.id)) {
         await NetworkController.switchActiveNetwork(network)
-        if (OptionsController.state.isSiweEnabled) {
-          const { SIWEController } = await import('@web3modal/siwe')
-          if (SIWEController.state._client?.options?.signOutOnNetworkChange) {
-            await SIWEController.signOut()
-          }
-        } else {
-          RouterUtil.navigateAfterNetworkSwitch()
-        }
+        await NetworkUtil.onNetworkChange()
       } else if (supportsAllNetworks) {
         RouterController.push('SwitchNetwork', { ...data, network })
       }

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -93,7 +93,7 @@ export class W3mFrameProvider {
     this.logger = generateChildLogger(logger, this.constructor.name)
     this.chunkLoggerController = chunkLoggerController
 
-    if (window !== undefined && this.chunkLoggerController?.downloadLogsBlobInBrowser) {
+    if (typeof window !== 'undefined' && this.chunkLoggerController?.downloadLogsBlobInBrowser) {
       // @ts-expect-error any
       if (!window.dowdownloadAppKitLogsBlob) {
         // @ts-expect-error any

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -93,7 +93,7 @@ export class W3mFrameProvider {
     this.logger = generateChildLogger(logger, this.constructor.name)
     this.chunkLoggerController = chunkLoggerController
 
-    if (window && this.chunkLoggerController?.downloadLogsBlobInBrowser) {
+    if (window !== undefined && this.chunkLoggerController?.downloadLogsBlobInBrowser) {
       // @ts-expect-error any
       if (!window.dowdownloadAppKitLogsBlob) {
         // @ts-expect-error any


### PR DESCRIPTION
# Summary
Fix issue where an integration with `signOutOnNetworkChange: false` would get stuck on the loading modal after switching in the wallet. 

# Changes

- feat:
- fix: close modal if there's no need to re-auth SIWE
- chore:

# Associated Issues

closes #APKT-596
