### PR TITLE
feat: includeWalletIds mapping to RDNS if 6963 is disabled

### DIFF
--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -1,59 +1,26 @@
 import { EthersTests } from '../../components/Ethers/EthersTests'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
-import { createWeb3Modal, defaultConfig } from '@web3modal/ethers5/react'
+import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
 import { ThemeStore } from '../../utils/StoreUtil'
+import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
-const SEPOLIA_NETWORK = {
-  chainId: 11155111,
-  name: 'Sepolia',
-  currency: 'ETH',
-  explorerUrl: 'https://sepolia.etherscan.io',
-  rpcUrl: 'https://rpc.sepolia.org'
-}
-
-function getConfig() {
-  const metadata = {
-    name: 'F test',
-    description: 'F test desc',
-    url: 'https://forbes.com',
-    icons: ['']
-  }
-
-  return {
-    configOptions: {
-      metadata,
-      enableEIP6963: false
-    },
-    modalOptions: {
-      chains: [SEPOLIA_NETWORK],
-      projectId: ConstantsUtil.ProjectId,
-      enableAnalytics: false,
-      enableEmail: false,
-      themeVariables: {
-        // Styling to match Forbes designs
-        '--w3m-border-radius-master': '8',
-        '--w3m-accent': '#EC002A',
-        '--w3m-color-mix-strength': 0
-      },
-      featuredWalletIds: [
-        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
-        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
-      ],
-      includeWalletIds: [
-        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
-        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
-      ],
-      allowUnsupportedChain: false,
-      allWallets: 'HIDE' as const
-    }
-  }
-}
-const config = getConfig()
 const modal = createWeb3Modal({
-  ethersConfig: defaultConfig(config.configOptions),
-  ...config.modalOptions
+  ethersConfig: defaultConfig({
+    metadata: ConstantsUtil.Metadata,
+    defaultChainId: 1,
+    rpcUrl: 'https://cloudflare-eth.com',
+    chains: EthersConstants.chains,
+    coinbasePreference: 'smartWalletOnly'
+  }),
+  chains: EthersConstants.chains,
+  projectId: ConstantsUtil.ProjectId,
+  enableAnalytics: true,
+  metadata: ConstantsUtil.Metadata,
+  termsConditionsUrl: 'https://walletconnect.com/terms',
+  privacyPolicyUrl: 'https://walletconnect.com/privacy',
+  customWallets: ConstantsUtil.CustomWallets
 })
 
 ThemeStore.setModal(modal)

--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -1,56 +1,26 @@
 import { EthersTests } from '../../components/Ethers/EthersTests'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
-import { createWeb3Modal, defaultConfig } from '@web3modal/ethers5/react'
+import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
 import { ThemeStore } from '../../utils/StoreUtil'
+import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
-const SEPOLIA_NETWORK = {
-  chainId: 11155111,
-  name: 'Sepolia',
-  currency: 'ETH',
-  explorerUrl: 'https://sepolia.etherscan.io',
-  rpcUrl: 'https://rpc.sepolia.org'
-}
-
-function getConfig() {
-  const metadata = {
-    name: 'Forbes test',
-    description: 'Forbes test desc',
-    url: 'https://forbes.com',
-    icons: []
-  }
-
-  return {
-    configOptions: metadata,
-    modalOptions: {
-      chains: [SEPOLIA_NETWORK],
-      projectId: ConstantsUtil.ProjectId,
-      enableAnalytics: false,
-      enableEmail: false,
-      themeVariables: {
-        // Styling to match Forbes designs
-        '--w3m-border-radius-master': '8',
-        '--w3m-accent': '#EC002A',
-        '--w3m-color-mix-strength': 0
-      },
-      featuredWalletIds: [
-        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
-        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
-      ],
-      includeWalletIds: [
-        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
-        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
-      ],
-      allowUnsupportedChain: false,
-      allWallets: 'HIDE' as const
-    }
-  }
-}
-const config = getConfig()
 const modal = createWeb3Modal({
-  ethersConfig: defaultConfig({ metadata: config.configOptions }),
-  ...config.modalOptions
+  ethersConfig: defaultConfig({
+    metadata: ConstantsUtil.Metadata,
+    defaultChainId: 1,
+    rpcUrl: 'https://cloudflare-eth.com',
+    chains: EthersConstants.chains,
+    coinbasePreference: 'smartWalletOnly'
+  }),
+  chains: EthersConstants.chains,
+  projectId: ConstantsUtil.ProjectId,
+  enableAnalytics: true,
+  metadata: ConstantsUtil.Metadata,
+  termsConditionsUrl: 'https://walletconnect.com/terms',
+  privacyPolicyUrl: 'https://walletconnect.com/privacy',
+  customWallets: ConstantsUtil.CustomWallets
 })
 
 ThemeStore.setModal(modal)

--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -1,26 +1,59 @@
 import { EthersTests } from '../../components/Ethers/EthersTests'
 import { Web3ModalButtons } from '../../components/Web3ModalButtons'
-import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
+import { createWeb3Modal, defaultConfig } from '@web3modal/ethers5/react'
 import { ThemeStore } from '../../utils/StoreUtil'
-import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
+const SEPOLIA_NETWORK = {
+  chainId: 11155111,
+  name: 'Sepolia',
+  currency: 'ETH',
+  explorerUrl: 'https://sepolia.etherscan.io',
+  rpcUrl: 'https://rpc.sepolia.org'
+}
+
+function getConfig() {
+  const metadata = {
+    name: 'F test',
+    description: 'F test desc',
+    url: 'https://forbes.com',
+    icons: ['']
+  }
+
+  return {
+    configOptions: {
+      metadata,
+      enableEIP6963: false
+    },
+    modalOptions: {
+      chains: [SEPOLIA_NETWORK],
+      projectId: ConstantsUtil.ProjectId,
+      enableAnalytics: false,
+      enableEmail: false,
+      themeVariables: {
+        // Styling to match Forbes designs
+        '--w3m-border-radius-master': '8',
+        '--w3m-accent': '#EC002A',
+        '--w3m-color-mix-strength': 0
+      },
+      featuredWalletIds: [
+        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
+        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
+      ],
+      includeWalletIds: [
+        'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96',
+        'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'
+      ],
+      allowUnsupportedChain: false,
+      allWallets: 'HIDE' as const
+    }
+  }
+}
+const config = getConfig()
 const modal = createWeb3Modal({
-  ethersConfig: defaultConfig({
-    metadata: ConstantsUtil.Metadata,
-    defaultChainId: 1,
-    rpcUrl: 'https://cloudflare-eth.com',
-    chains: EthersConstants.chains,
-    coinbasePreference: 'smartWalletOnly'
-  }),
-  chains: EthersConstants.chains,
-  projectId: ConstantsUtil.ProjectId,
-  enableAnalytics: true,
-  metadata: ConstantsUtil.Metadata,
-  termsConditionsUrl: 'https://walletconnect.com/terms',
-  privacyPolicyUrl: 'https://walletconnect.com/privacy',
-  customWallets: ConstantsUtil.CustomWallets
+  ethersConfig: defaultConfig(config.configOptions),
+  ...config.modalOptions
 })
 
 ThemeStore.setModal(modal)

--- a/packages/core/src/controllers/OptionsController.ts
+++ b/packages/core/src/controllers/OptionsController.ts
@@ -104,7 +104,7 @@ export const OptionsController = {
     state.disableAppend = disableAppend
   },
 
-  setEnableEIP6963(enableEIP6963: OptionsControllerState['enableEIP6963']) {
+  setEIP6963Enabled(enableEIP6963: OptionsControllerState['enableEIP6963']) {
     state.enableEIP6963 = enableEIP6963
   },
 

--- a/packages/core/src/controllers/OptionsController.ts
+++ b/packages/core/src/controllers/OptionsController.ts
@@ -21,6 +21,7 @@ export interface OptionsControllerState {
   metadata?: Metadata
   enableOnramp?: boolean
   disableAppend?: boolean
+  enableEIP6963?: boolean
 }
 
 type StateKey = keyof OptionsControllerState
@@ -101,6 +102,10 @@ export const OptionsController = {
 
   setDisableAppend(disableAppend: OptionsControllerState['disableAppend']) {
     state.disableAppend = disableAppend
+  },
+
+  setEnableEIP6963(enableEIP6963: OptionsControllerState['enableEIP6963']) {
+    state.enableEIP6963 = enableEIP6963
   },
 
   getSnapshot() {

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -141,6 +141,12 @@ export class Web3Modal extends Web3ModalScaffold {
       throw new Error('web3modal:constructor - projectId is undefined')
     }
 
+    if (ethersConfig.EIP6963) {
+      ethersConfig.EIP6963.forEach(provider => {
+        this.EIP6963Providers.push(provider)
+      })
+    }
+
     const networkControllerClient: NetworkControllerClient = {
       switchCaipNetwork: async caipNetwork => {
         const chainId = NetworkUtil.caipNetworkIdToNumber(caipNetwork?.id)
@@ -502,11 +508,10 @@ export class Web3Modal extends Web3ModalScaffold {
     this.syncRequestedNetworks(chains, chainImages)
     this.syncConnectors(ethersConfig)
 
-    if (ethersConfig.EIP6963) {
-      if (typeof window !== 'undefined') {
-        this.listenConnectors(ethersConfig.EIP6963)
-        this.checkActive6963Provider()
-      }
+    // Setup EIP6963 providers
+    if (typeof window !== 'undefined') {
+      this.listenConnectors(true)
+      this.checkActive6963Provider()
     }
 
     if (ethersConfig.injected) {

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -508,6 +508,8 @@ export class Web3Modal extends Web3ModalScaffold {
       this.checkActive6963Provider()
     }
 
+    this.setEIP6963Enabled(ethersConfig.EIP6963 !== false)
+
     if (ethersConfig.injected) {
       this.checkActiveInjectedProvider(ethersConfig)
     }
@@ -518,10 +520,6 @@ export class Web3Modal extends Web3ModalScaffold {
 
     if (ethersConfig.coinbase) {
       this.checkActiveCoinbaseProvider(ethersConfig)
-    }
-
-    if (ethersConfig.EIP6963) {
-      this.setEIP6963Enabled(true)
     }
   }
 

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -141,12 +141,6 @@ export class Web3Modal extends Web3ModalScaffold {
       throw new Error('web3modal:constructor - projectId is undefined')
     }
 
-    if (ethersConfig.EIP6963) {
-      ethersConfig.EIP6963.forEach(provider => {
-        this.EIP6963Providers.push(provider)
-      })
-    }
-
     const networkControllerClient: NetworkControllerClient = {
       switchCaipNetwork: async caipNetwork => {
         const chainId = NetworkUtil.caipNetworkIdToNumber(caipNetwork?.id)
@@ -524,6 +518,10 @@ export class Web3Modal extends Web3ModalScaffold {
 
     if (ethersConfig.coinbase) {
       this.checkActiveCoinbaseProvider(ethersConfig)
+    }
+
+    if (ethersConfig.EIP6963) {
+      this.setEIP6963Enabled(true)
     }
   }
 

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -393,6 +393,10 @@ export class Web3Modal extends Web3ModalScaffold {
       this.listenConnectors(true)
       this.checkActive6963Provider()
     }
+
+    if (ethersConfig.EIP6963) {
+      this.setEIP6963Enabled(true)
+    }
   }
 
   // -- Public ------------------------------------------------------------------

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -384,15 +384,14 @@ export class Web3Modal extends Web3ModalScaffold {
       this.checkActiveInjectedProvider(ethersConfig)
     }
 
-    if (ethersConfig.EIP6963) {
-      if (typeof window !== 'undefined') {
-        this.listenConnectors(ethersConfig.EIP6963)
-        this.checkActive6963Provider()
-      }
-    }
-
     if (ethersConfig.coinbase) {
       this.checkActiveCoinbaseProvider(ethersConfig)
+    }
+
+    // Setup EIP6963 providers
+    if (typeof window !== 'undefined') {
+      this.listenConnectors(true)
+      this.checkActive6963Provider()
     }
   }
 

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -394,9 +394,7 @@ export class Web3Modal extends Web3ModalScaffold {
       this.checkActive6963Provider()
     }
 
-    if (ethersConfig.EIP6963) {
-      this.setEIP6963Enabled(true)
-    }
+    this.setEIP6963Enabled(ethersConfig.EIP6963 !== false)
   }
 
   // -- Public ------------------------------------------------------------------

--- a/packages/scaffold-ui/src/partials/w3m-connect-featured-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-featured-widget/index.ts
@@ -1,5 +1,5 @@
 import type { WcWallet } from '@web3modal/core'
-import { ApiController, AssetUtil, RouterController } from '@web3modal/core'
+import { ApiController, AssetUtil, ConnectorController, RouterController } from '@web3modal/core'
 import { customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
 import { ifDefined } from 'lit/directives/if-defined.js'
@@ -43,7 +43,12 @@ export class W3mConnectFeaturedWidget extends LitElement {
 
   // -- Private Methods ----------------------------------- //
   private onConnectWallet(wallet: WcWallet) {
-    RouterController.push('ConnectingWalletConnect', { wallet })
+    const connector = ConnectorController.getConnector(wallet.id, wallet.rdns)
+    if (connector) {
+      RouterController.push('ConnectingExternal', { connector })
+    } else {
+      RouterController.push('ConnectingWalletConnect', { wallet })
+    }
   }
 }
 

--- a/packages/scaffold-ui/src/partials/w3m-connect-recommended-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-recommended-widget/index.ts
@@ -80,7 +80,12 @@ export class W3mConnectRecommendedWidget extends LitElement {
 
   // -- Private Methods ----------------------------------- //
   private onConnectWallet(wallet: WcWallet) {
-    RouterController.push('ConnectingWalletConnect', { wallet })
+    const connector = ConnectorController.getConnector(wallet.id, wallet.rdns)
+    if (connector) {
+      RouterController.push('ConnectingExternal', { connector })
+    } else {
+      RouterController.push('ConnectingWalletConnect', { wallet })
+    }
   }
 }
 

--- a/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
@@ -71,9 +71,9 @@ export class W3mConnectorList extends LitElement {
     return {
       custom,
       recent,
-      announced,
       coinbase,
-      injected,
+      announced: OptionsController.enableEIP6963 ? announced : [],
+      injected: OptionsController.enableEIP6963 ? injected : [],
       recommended: filteredRecommended,
       featured: filteredFeatured
     }

--- a/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
@@ -72,8 +72,8 @@ export class W3mConnectorList extends LitElement {
       custom,
       recent,
       coinbase,
-      announced: OptionsController.enableEIP6963 ? announced : [],
-      injected: OptionsController.enableEIP6963 ? injected : [],
+      announced: OptionsController.state.enableEIP6963 ? announced : [],
+      injected: OptionsController.state.enableEIP6963 ? injected : [],
       recommended: filteredRecommended,
       featured: filteredFeatured
     }

--- a/packages/scaffold-ui/src/utils/WalletUtil.ts
+++ b/packages/scaffold-ui/src/utils/WalletUtil.ts
@@ -1,8 +1,16 @@
-import { ConnectorController, CoreHelperUtil, StorageUtil, type WcWallet } from '@web3modal/core'
+import {
+  ConnectorController,
+  CoreHelperUtil,
+  OptionsController,
+  StorageUtil,
+  type WcWallet
+} from '@web3modal/core'
 
 export const WalletUtil = {
   filterOutDuplicatesByRDNS(wallets: WcWallet[]) {
-    const connectors = ConnectorController.state.connectors
+    const connectors = OptionsController.state.enableEIP6963
+      ? ConnectorController.state.connectors
+      : []
     const recent = StorageUtil.getRecentWallets()
 
     const connectorRDNSs = connectors

--- a/packages/scaffold/src/client.ts
+++ b/packages/scaffold/src/client.ts
@@ -271,6 +271,10 @@ export class Web3ModalScaffold {
     return networkNameAddresses[0]?.address || false
   }
 
+  protected setEIP6963Enabled: (typeof OptionsController)['setEIP6963Enabled'] = enabled => {
+    OptionsController.setEIP6963Enabled(enabled)
+  }
+
   // -- Private ------------------------------------------------------------------
   private async initControllers(options: ScaffoldOptions) {
     NetworkController.setClient(options.networkControllerClient)
@@ -289,8 +293,6 @@ export class Web3ModalScaffold {
     OptionsController.setSdkVersion(options._sdkVersion)
     // Enabled by default
     OptionsController.setOnrampEnabled(options.enableOnramp !== false)
-
-    OptionsController.setEnableEIP6963(options.enableEIP6963 !== false)
 
     if (options.metadata) {
       OptionsController.setMetadata(options.metadata)

--- a/packages/scaffold/src/client.ts
+++ b/packages/scaffold/src/client.ts
@@ -55,6 +55,7 @@ export interface LibraryOptions {
   disableAppend?: OptionsControllerState['disableAppend']
   allowUnsupportedChain?: NetworkControllerState['allowUnsupportedChain']
   _sdkVersion: OptionsControllerState['sdkVersion']
+  enableEIP6963?: OptionsControllerState['enableEIP6963']
 }
 
 export interface ScaffoldOptions extends LibraryOptions {
@@ -288,6 +289,8 @@ export class Web3ModalScaffold {
     OptionsController.setSdkVersion(options._sdkVersion)
     // Enabled by default
     OptionsController.setOnrampEnabled(options.enableOnramp !== false)
+
+    OptionsController.setEnableEIP6963(options.enableEIP6963 !== false)
 
     if (options.metadata) {
       OptionsController.setMetadata(options.metadata)

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -363,6 +363,10 @@ export class Web3Modal extends Web3ModalScaffold {
     watchAccount(this.wagmiConfig, {
       onChange: accountData => this.syncAccount({ ...accountData })
     })
+
+    if (w3mOptions.enableEIP6963) {
+      this.setEIP6963Enabled(true)
+    }
   }
 
   // -- Public ------------------------------------------------------------------

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -364,9 +364,7 @@ export class Web3Modal extends Web3ModalScaffold {
       onChange: accountData => this.syncAccount({ ...accountData })
     })
 
-    if (w3mOptions.enableEIP6963) {
-      this.setEIP6963Enabled(true)
-    }
+    this.setEIP6963Enabled(w3mOptions.enableEIP6963 !== false)
   }
 
   // -- Public ------------------------------------------------------------------


### PR DESCRIPTION
# Summary
If `enableEIP6963` was set to false, all other connectors wouldn't work, including wallets fetched from the API in web browser contexts. When utilizing the flags to include wallets from the API, these fetched wallets would show but have no underlying connector on web contexts, causing an unusable state.

This PR makes it so connectors are always initialized, but they are not shown if the flag is set to false. This way, they are readily available to be used as transport for api fetched wallets.

## Changes
- chore: refactor flow to have 6963 wallets available but hidden
- fix: issue on recommended, recent and featured connect wallet widgets where connector would not be used even if present
