### PR TITLE
fix: not allow multiple account syncs for same caip address

### DIFF
--- a/apps/laboratory/src/components/Wagmi/WagmiGetCallsStatusTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiGetCallsStatusTest.tsx
@@ -28,7 +28,7 @@ export function WagmiGetCallsStatusTest() {
   if (!isGetCallsStatusSupported()) {
     return (
       <Text fontSize="md" color="yellow">
-        Wallet does not support wallet_getCallsStatus rpc method
+        Wallet does not support the "wallet_getCallsStatus" RPC method
       </Text>
     )
   }

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsTest.tsx
@@ -44,7 +44,7 @@ export function WagmiSendCallsTest() {
   if (!isSendCallsSupported()) {
     return (
       <Text fontSize="md" color="yellow">
-        Wallet does not support wallet_sendCalls rpc method
+        Wallet does not support the "wallet_sendCalls" RPC method
       </Text>
     )
   }
@@ -52,7 +52,7 @@ export function WagmiSendCallsTest() {
   if (supportedChains.length === 0) {
     return (
       <Text fontSize="md" color="yellow">
-        Account does not support atomic batch feature
+        Account does not support the atomic batch feature
       </Text>
     )
   }

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsWithPaymasterServiceTest.tsx
@@ -44,7 +44,7 @@ export function WagmiSendCallsWithPaymasterServiceTest() {
   if (!isSendCallsSupported()) {
     return (
       <Text fontSize="md" color="yellow">
-        Wallet does not support wallet_sendCalls rpc method
+        Wallet does not support "wallet_sendCalls" RPC method
       </Text>
     )
   }

--- a/packages/scaffold/src/client.ts
+++ b/packages/scaffold/src/client.ts
@@ -204,6 +204,8 @@ export class Web3ModalScaffold {
     AccountController.removeAddressLabel(address)
   }
 
+  protected getCaipAddress = () => AccountController.state.caipAddress
+
   protected setCaipAddress: (typeof AccountController)['setCaipAddress'] = (caipAddress, chain) => {
     AccountController.setCaipAddress(caipAddress, chain)
   }

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -446,11 +446,16 @@ export class Web3Modal extends Web3ModalScaffold {
   }: Partial<
     Pick<GetAccountReturnType, 'address' | 'isConnected' | 'chainId' | 'connector' | 'addresses'>
   >) {
+    const caipAddress: CaipAddress = `${ConstantsUtil.EIP155}:${chainId}:${address}`
+
+    if (this.getCaipAddress() === caipAddress) {
+      return
+    }
+
     this.resetAccount()
     this.syncNetwork(address, chainId, isConnected)
-    const isAuthConnecor = connector?.id === ConstantsUtil.AUTH_CONNECTOR_ID
+
     if (isConnected && address && chainId) {
-      const caipAddress: CaipAddress = `${ConstantsUtil.EIP155}:${chainId}:${address}`
       this.setIsConnected(isConnected)
       this.setCaipAddress(caipAddress)
       await Promise.all([
@@ -463,7 +468,8 @@ export class Web3Modal extends Web3ModalScaffold {
       }
 
       // Set by authConnector.onIsConnectedHandler as we need the account type
-      if (!isAuthConnecor && addresses?.length) {
+      const isAuthConnector = connector?.id === ConstantsUtil.AUTH_CONNECTOR_ID
+      if (!isAuthConnector && addresses?.length) {
         this.setAllAccounts(addresses.map(addr => ({ address: addr, type: 'eoa' })))
       }
 


### PR DESCRIPTION
# Description

This PR is changing the `syncAccount` function over wagmi `Web3Modal` client to not allow the account data to be fetched twice for the same CAIP. This fixes the issue with account data being fetched multiple times between wagmi's `watchAccount` onChange callbacks.

Edit: This PR doesn't contain test coverage because the testing setup is a wip being done by @enesozturk.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

APKT-684

# Showcase (Optional)

The change can be seen on [here](https://web3modal-laboratory-git-fix-multiple-acc-b5c937-walletconnect1.vercel.app/library/wagmi/) compared to [live](https://lab.web3modal.com/library/wagmi/), when the account is connected and you refresh the page it updates a single the account info a single time.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
