### PR TITLE
fix: missing network not supported modal on wallet network switch

### DIFF
--- a/apps/laboratory/tests/shared/pages/WalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/WalletPage.ts
@@ -74,4 +74,29 @@ export class WalletPage {
     await btn.focus()
     await this.page.keyboard.press('Space')
   }
+
+  /**
+   * Enables testnets in the wallet settings
+   */
+  async enableTestnets() {
+    await this.page.waitForLoadState()
+    const settingsButton = this.page.getByTestId('settings')
+    await settingsButton.click()
+    const testnetSwitch = this.page.getByTestId('settings-toggle-testnets')
+    await testnetSwitch.click()
+    expect(testnetSwitch).toHaveAttribute('data-state', 'checked')
+  }
+
+  /**
+   * Switches the network in the wallet
+   * @param network the network id to switch (e.g. eip155:1 for Ethereum Mainnet)
+   */
+  async switchNetwork(network: string) {
+    await this.page.waitForLoadState()
+    const networkButton = this.page.getByTestId('accounts')
+    await networkButton.click()
+    const switchNetworkButton = this.page.getByTestId(`chain-switch-button${network}`)
+    await switchNetworkButton.click()
+    await expect(switchNetworkButton).toHaveText('✅')
+  }
 }

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -116,4 +116,14 @@ export class ModalValidator {
 
     expect(accounts.length).toBeGreaterThan(1)
   }
+
+  async expectNetworkNotSupportedVisible() {
+    const networkNotSupportedMessage = this.page.getByText(
+      'This app doesn’t support your current network. Switch to an available option to continue.'
+    )
+    await expect(
+      networkNotSupportedMessage,
+      'Network not supported message should be visible'
+    ).toBeVisible()
+  }
 }

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -78,3 +78,16 @@ testConnectedMW('it should show multiple accounts', async ({ modalPage, modalVal
   await modalValidator.expectMultipleAccounts()
   await modalPage.closeModal()
 })
+
+testConnectedMW.only(
+  'it should show Switch Network modal if network is not supported',
+  async ({ modalPage, modalValidator, walletPage }) => {
+    if (modalPage.library === 'solana') {
+      return
+    }
+    await walletPage.enableTestnets()
+    await walletPage.switchNetwork('eip155:5')
+    await modalValidator.expectNetworkNotSupportedVisible()
+    await modalPage.closeModal()
+  }
+)

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -79,7 +79,7 @@ testConnectedMW('it should show multiple accounts', async ({ modalPage, modalVal
   await modalPage.closeModal()
 })
 
-testConnectedMW.only(
+testConnectedMW(
   'it should show Switch Network modal if network is not supported',
   async ({ modalPage, modalValidator, walletPage }) => {
     if (modalPage.library === 'solana') {

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -91,7 +91,11 @@ export const NetworkController = {
     PublicStateController.set({ activeChain: chain, selectedNetworkId: caipNetwork?.id })
 
     if (!ChainController.state.chains.get(chain)?.networkState?.allowUnsupportedChain) {
-      this.checkIfSupportedNetwork()
+      const isSupported = this.checkIfSupportedNetwork()
+
+      if (!isSupported) {
+        this.showUnsupportedChainUI()
+      }
     }
   },
 
@@ -258,9 +262,7 @@ export const NetworkController = {
   },
 
   checkIfSupportedNetwork() {
-    const chain = ChainController.state.multiChainEnabled
-      ? ChainController.state.activeChain
-      : ChainController.state.activeChain
+    const chain = ChainController.state.activeChain
 
     if (!chain) {
       return false


### PR DESCRIPTION
# Description

This PR readds the modal opening when there is a change in the wallet for a network that is not supported by the app.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes APKT-694
closes #2518

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

https://github.com/user-attachments/assets/1fb93534-3f47-475b-8147-d6fd827710b3



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
