### PR TITLE
fix: remove 200ms QR delay

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-desktop/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-desktop/index.ts
@@ -22,9 +22,7 @@ export class W3mConnectingWcDesktop extends W3mConnectingWidget {
   private onRenderProxy() {
     if (!this.ready && this.uri) {
       this.ready = true
-      this.timeout = setTimeout(() => {
-        this.onConnect?.()
-      }, 200)
+      this.onConnect?.()
     }
   }
 

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-qrcode/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-qrcode/index.ts
@@ -50,9 +50,10 @@ export class W3mConnectingWcQrcode extends W3mConnectingWidget {
   // -- Private ------------------------------------------- //
   private onRenderProxy() {
     if (!this.ready && this.uri) {
+      // This setTimeout needed to avoid the beginning of the animation from not starting to resize immediately and some weird svg errors
       this.timeout = setTimeout(() => {
         this.ready = true
-      }, 200)
+      }, 0)
     }
   }
 


### PR DESCRIPTION
# Description

Removes excessive delay to display QR codes. Seems like a `setTimeout(..., 0)` is required for the WalletConnect button case as without it the resizing animation is delayed and there are svg errors for some reason. This issue isn't on the desktop QR.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
