### PR TITLE
refactor: use chain id for the transports array mapping

### DIFF
--- a/packages/wagmi/src/utils/defaultWagmiCoreConfig.ts
+++ b/packages/wagmi/src/utils/defaultWagmiCoreConfig.ts
@@ -41,7 +41,7 @@ export function defaultWagmiConfig({
   ...wagmiConfig
 }: ConfigOptions): Config {
   const connectors: CreateConnectorFn[] = wagmiConfig?.connectors ?? []
-  const transportsArr = chains.map(chain => [chain, getTransport({ chain, projectId })])
+  const transportsArr = chains.map(chain => [chain.id, getTransport({ chain, projectId })])
   const transports = Object.fromEntries(transportsArr)
   const defaultAuth = {
     email: true,


### PR DESCRIPTION
# Description

We [previously refactored](https://github.com/WalletConnect/web3modal/pull/2119/files#diff-b8b34b308c4640de370e32093cd7f927efbf66d70cf48c397a0f3dfb5af7d228R44) our logic to create `transports` array for `wagmi`, to use `chain` object directly instead of `chain.id` in the `defaultWagmiReactConfig.ts`. But we still use `chain.id` in the `defaultWagmiCoreConfig.ts`. Wagmi is looking for chainID while mapping the transport objects, as could be seen in any dApp that uses our package `>=5.0.6`:

```sh
TypeError: rest.transports[chainId] is not a function
    at Object.transport (createConfig.js:121:66)
    at createClient (createClient.js:15:51)
    at Object.getClient (createConfig.js:115:72)
```

This PR introduces changes to revert this back. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
