### PR TITLE
refactor/skip ui tests on draft

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -17,31 +17,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event.action == 'opened' || github.event.action == 'synchronize'
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-
-      - name: setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: 'pnpm'
-
-      - name: install
-        run: pnpm install
-
-      - name: build
-        run: pnpm build
-        env:
-          NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
-
   code_style:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -2,6 +2,7 @@ name: Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - V3
       - V4
@@ -95,6 +96,7 @@ jobs:
           json-summary-path: ./coverage/coverage-merged-summary.json
 
   ui-test:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/ui_tests.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -79,10 +79,6 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['apps/laboratory']['devDependencies']['@playwright/test'])")" >> $GITHUB_ENV
 
-      - name: Install Brave Browser
-        working-directory: ./apps/laboratory/
-        run: sudo ./scripts/install-brave-browser.sh
-
       - name: Cache playwright binaries
         uses: actions/cache@v4
         id: playwright-cache


### PR DESCRIPTION
# Description

Introduces changes to GitHub workflows to disable tests E2E tests on draft PRs. Additionally removes `build` step since we already building our codebase in all steps like `code_check`, `test`, and `ui_tests`.

See example: https://github.com/WalletConnect/web3modal/pull/2528

<img width="853" alt="Screenshot 2024-07-30 at 16 48 35" src="https://github.com/user-attachments/assets/b5b37521-0cb9-42f4-86af-5e746dedbf93">


### Resources

- https://github.com/orgs/community/discussions/25722#discussioncomment-3248919


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
