### PR TITLE
fix: remove limitation on sending versioned tx

### DIFF
--- a/apps/laboratory/src/components/Solana/SolanaSendTransactionTest.tsx
+++ b/apps/laboratory/src/components/Solana/SolanaSendTransactionTest.tsx
@@ -139,8 +139,6 @@ export function SolanaSendTransactionTest() {
     )
   }
 
-  const supportV0Transactions = walletProvider?.name !== 'WalletConnect'
-
   return (
     <Stack direction={['column', 'column', 'row']}>
       <Button
@@ -150,15 +148,13 @@ export function SolanaSendTransactionTest() {
       >
         Sign and Send Transaction
       </Button>
-      {supportV0Transactions ? (
-        <Button
-          data-test-id="sign-transaction-button"
-          onClick={onSendVersionedTransaction}
-          isDisabled={loading}
-        >
-          Sign and Send Versioned Transaction
-        </Button>
-      ) : null}
+      <Button
+        data-test-id="sign-transaction-button"
+        onClick={onSendVersionedTransaction}
+        isDisabled={loading}
+      >
+        Sign and Send Versioned Transaction
+      </Button>
       <Spacer />
 
       <Link isExternal href="https://solfaucet.com/">


### PR DESCRIPTION
# Description
Enable sign and send versioned transactions on `/solana`

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests) => No way to test as of now. test wallet does not support solana v0 txs
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
