### PR TITLE
refactor: fix missing ens screens

### DIFF
--- a/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalWalletPage.ts
@@ -16,6 +16,18 @@ export class ModalWalletPage extends ModalPage {
     await this.page.getByTestId('account-settings-button').click()
   }
 
+  async openChooseNameIntro() {
+    await this.page.getByTestId('account-choose-name-button').click()
+  }
+
+  async openChooseName() {
+    await this.page.getByRole('button', { name: 'Choose Name' }).click()
+  }
+
+  async typeName(name: string) {
+    await this.page.getByTestId('wui-ens-input').getByTestId('wui-input-text').fill(name)
+  }
+
   override async switchNetwork(network: string) {
     await this.page.getByTestId('account-switch-network-button').click()
     await this.page.getByTestId(`w3m-network-switch-${network}`).click()

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -141,4 +141,9 @@ export class ModalValidator {
       await expect(onrampButton).toBeVisible()
     }
   }
+
+  async expectAccountNameFound(name: string) {
+    const suggestion = this.page.getByTestId('account-name-suggestion').getByText(name)
+    await expect(suggestion).toBeVisible()
+  }
 }

--- a/apps/laboratory/tests/wallet-features.spec.ts
+++ b/apps/laboratory/tests/wallet-features.spec.ts
@@ -40,7 +40,7 @@ walletFeaturesTest.afterAll(async () => {
   await page.page.close()
 })
 
-walletFeaturesTest('it should initialize swap as expected', async () => {
+walletFeaturesTest.skip('it should initialize swap as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('swap')
   await walletFeatureButton.click()
@@ -56,7 +56,7 @@ walletFeaturesTest('it should initialize swap as expected', async () => {
   await page.closeModal()
 })
 
-walletFeaturesTest('it should initialize onramp as expected', async () => {
+walletFeaturesTest.skip('it should initialize onramp as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('onramp')
   await walletFeatureButton.click()
@@ -64,11 +64,26 @@ walletFeaturesTest('it should initialize onramp as expected', async () => {
   await page.closeModal()
 })
 
-walletFeaturesTest('it should initialize receive as expected', async () => {
+walletFeaturesTest.skip('it should initialize receive as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('receive')
   await walletFeatureButton.click()
   await page.page.getByTestId('receive-address-copy-button').click()
   await expect(page.page.getByText('Address copied')).toBeVisible()
+  await page.closeModal()
+})
+
+walletFeaturesTest('it should find account name as expected', async () => {
+  await page.openAccount()
+  await page.openProfileView()
+  await page.openSettings()
+
+  await page.switchNetwork('Polygon')
+  await validator.expectSwitchedNetwork('Polygon')
+
+  await page.openChooseNameIntro()
+  await page.openChooseName()
+  await page.typeName('test-ens-check')
+  await validator.expectAccountNameFound('test-ens-check')
   await page.closeModal()
 })

--- a/apps/laboratory/tests/wallet-features.spec.ts
+++ b/apps/laboratory/tests/wallet-features.spec.ts
@@ -40,7 +40,7 @@ walletFeaturesTest.afterAll(async () => {
   await page.page.close()
 })
 
-walletFeaturesTest.skip('it should initialize swap as expected', async () => {
+walletFeaturesTest('it should initialize swap as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('swap')
   await walletFeatureButton.click()
@@ -56,7 +56,7 @@ walletFeaturesTest.skip('it should initialize swap as expected', async () => {
   await page.closeModal()
 })
 
-walletFeaturesTest.skip('it should initialize onramp as expected', async () => {
+walletFeaturesTest('it should initialize onramp as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('onramp')
   await walletFeatureButton.click()
@@ -64,7 +64,7 @@ walletFeaturesTest.skip('it should initialize onramp as expected', async () => {
   await page.closeModal()
 })
 
-walletFeaturesTest.skip('it should initialize receive as expected', async () => {
+walletFeaturesTest('it should initialize receive as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('receive')
   await walletFeatureButton.click()

--- a/packages/scaffold-ui/src/modal/w3m-router/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-router/index.ts
@@ -145,6 +145,10 @@ export class W3mRouter extends LitElement {
         return html`<w3m-what-is-a-network-view></w3m-what-is-a-network-view>`
       case 'ConnectingFarcaster':
         return html`<w3m-connecting-farcaster-view></w3m-connecting-farcaster-view>`
+      case 'RegisterAccountName':
+        return html`<w3m-register-account-name-view></w3m-register-account-name-view>`
+      case 'RegisterAccountNameSuccess':
+        return html`<w3m-register-account-name-success-view></w3m-register-account-name-success-view>`
       default:
         return html`<w3m-connect-view></w3m-connect-view>`
     }

--- a/packages/scaffold-ui/src/views/w3m-register-account-name-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-register-account-name-view/index.ts
@@ -151,6 +151,7 @@ export class W3mRegisterAccountNameView extends LitElement {
 
     return html`<wui-flex flexDirection="column" gap="xxs" alignItems="center">
       <wui-flex
+        data-testid="account-name-suggestion"
         .padding=${['m', 'm', 'm', 'm'] as const}
         justifyContent="space-between"
         class="suggestion"
@@ -165,6 +166,7 @@ export class W3mRegisterAccountNameView extends LitElement {
 
   private availableNameTemplate(suggestion: string) {
     return html` <wui-flex
+      data-testid="account-name-suggestion"
       .padding=${['m', 'm', 'm', 'm'] as const}
       justifyContent="space-between"
       class="suggestion"

--- a/packages/ui/src/composites/wui-input-text/index.ts
+++ b/packages/ui/src/composites/wui-input-text/index.ts
@@ -44,6 +44,7 @@ export class WuiInputText extends LitElement {
 
     return html`${this.templateIcon()}
       <input
+        data-testid="wui-input-text"
         ${ref(this.inputElementRef)}
         class=${classMap(classes)}
         type=${this.type}


### PR DESCRIPTION
# Description

Add missing screens for ENS names in `w3m-router`. Introduces test for checking account name.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-835

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
