### PR TITLE
fix: import types from the package root in partials

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-activity-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-activity-list/index.ts
@@ -11,7 +11,7 @@ import {
 import { TransactionUtil, customElement } from '@web3modal/ui'
 import { LitElement, html } from 'lit'
 import { property, state } from 'lit/decorators.js'
-import type { TransactionType } from '@web3modal/ui/src/utils/TypeUtil.js'
+import type { TransactionType } from '@web3modal/ui'
 import { W3mFrameRpcConstants } from '@web3modal/wallet'
 import { ConstantsUtil } from '@web3modal/common'
 

--- a/packages/scaffold-ui/src/partials/w3m-onramp-activity-item/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-onramp-activity-item/index.ts
@@ -1,7 +1,6 @@
 import { html, LitElement } from 'lit'
 import { property } from 'lit/decorators.js'
-import { customElement } from '@web3modal/ui'
-import type { ColorType } from '@web3modal/ui/src/utils/TypeUtil.js'
+import { customElement, type ColorType } from '@web3modal/ui'
 import { ApiController } from '@web3modal/core'
 import styles from './styles.js'
 

--- a/packages/scaffold-ui/src/partials/w3m-onramp-provider-item/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-onramp-provider-item/index.ts
@@ -1,8 +1,7 @@
 import { html, LitElement } from 'lit'
 import { property } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
-import { customElement } from '@web3modal/ui'
-import type { ColorType } from '@web3modal/ui/src/utils/TypeUtil.js'
+import { customElement, type ColorType } from '@web3modal/ui'
 import { AssetUtil, NetworkController, type OnRampProvider } from '@web3modal/core'
 import styles from './styles.js'
 

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -85,4 +85,4 @@ export { UiHelperUtil } from './src/utils/UiHelperUtil.js'
 export { TransactionUtil } from './src/utils/TransactionUtil.js'
 export { customElement } from './src/utils/WebComponentsUtil.js'
 
-export type { IconType, VisualType, ColorType } from './src/utils/TypeUtil.js'
+export type { IconType, VisualType, ColorType, TransactionType } from './src/utils/TypeUtil.js'


### PR DESCRIPTION
# Description

In the `scaffold-ui` which have dependency of `ui` package, we are importing some type definitions by using the full path, which we shouldn't do due to resolving modules. This PR introduces changes to import paths. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-844

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
