### PR TITLE
fix(solana): injected connectors not detected

### DIFF
--- a/apps/laboratory/tests/metamask.spec.ts
+++ b/apps/laboratory/tests/metamask.spec.ts
@@ -20,3 +20,10 @@ synpressTest('should be connected as expected', async ({ page, metamask }) => {
   await metamask.connectToDapp()
   await modalValidator.expectConnected()
 })
+
+synpressTest('should show injected connectors on Solana as expected', async ({ page }) => {
+  await page.goto(`/library/solana`)
+  await page.getByTestId('connect-button').click()
+  const connectMetaMaskButton = page.getByTestId('wallet-selector-MetaMask')
+  await expect(connectMetaMaskButton).toBeVisible()
+})

--- a/packages/solana/src/utils/wallet-standard/watchStandard.ts
+++ b/packages/solana/src/utils/wallet-standard/watchStandard.ts
@@ -25,6 +25,8 @@ export function watchStandard(callback: (arg: StandardWalletAdapter[]) => void) 
     })
   ]
 
+  callback(standardAdapters)
+
   return () => listeners.forEach(off => off())
 }
 


### PR DESCRIPTION
# Description

Wallet Standard's `on` listener is not getting triggered when MM is disabled but other extensions like Trust or Phantom is enabled. This causing an issue that the none of the injected wallets are getting visible in connector list if MM is not installed or disabled. 

This PR introduces a slight changes to the `watchStandard` method to make sure it's passing the available options to it's `callback` parameter. 

Also adding a tests that checks the MM option in the injected connectors list.

While this resolving the issue, like to double checking the issue with the Wallet Standard team here: https://github.com/wallet-standard/wallet-standard/issues/109

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-845
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
