### PR TITLE
chore: renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,12 +27,12 @@
     },
     {
       "enabled": true,
-      "matchPackageNames": ["@wagmi/core", "wagmi", "@wagmi/connectors"],
+      "matchPackageNames": ["viem", "@wagmi/core", "wagmi", "@wagmi/connectors"],
       "groupName": "wagmi"
     },
     {
       "enabled": true,
-      "matchPackageNames": ["viem", "ethers", "@solana/web3.js"]
+      "matchPackageNames": ["ethers", "@solana/web3.js"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,11 @@
     ":semanticCommitScope(deps)"
   ],
   "rebaseWhen": "conflicted",
+  "includePaths": ["examples/**"],
   "packageRules": [
     {
-      "matchPackagePatterns": ["*"],
-      "enabled": false
+      "enabled": false,
+      "matchPackageNames": ["*"]
     },
     {
       "enabled": true,
@@ -24,9 +25,9 @@
         "@wagmi/connectors",
         "viem",
         "ethers",
-        "@solana/web3.js"
+        "@solana/web3.js",
+        "@web3modal/{/,}**"
       ],
-      "matchPackagePrefixes": ["@web3modal/"],
       "prPriority": 10
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -20,15 +20,19 @@
         "@walletconnect/ethereum-provider",
         "@walletconnect/universal-provider",
         "@walletconnect/utils",
-        "@wagmi/core",
-        "wagmi",
-        "@wagmi/connectors",
-        "viem",
-        "ethers",
-        "@solana/web3.js",
         "@web3modal/{/,}**"
       ],
+      "groupName": "walletconnect",
       "prPriority": 10
+    },
+    {
+      "enabled": true,
+      "matchPackageNames": ["@wagmi/core", "wagmi", "@wagmi/connectors"],
+      "groupName": "wagmi"
+    },
+    {
+      "enabled": true,
+      "matchPackageNames": ["viem", "ethers", "@solana/web3.js"]
     }
   ]
 }


### PR DESCRIPTION
- Include `examples` path since these are [ignored by default](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests)
- Group related and possibly dependent dependencies together in the same PR
- Apply recommended schema migration:
```
 WARN: Config migration necessary
       "oldConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": [
           "config:best-practices",
           ":prConcurrentLimit10",
           ":prHourlyLimit2",
           ":semanticCommits",
           ":semanticCommitScope(deps)"
         ],
         "rebaseWhen": "conflicted",
         "packageRules": [
           {"matchPackagePatterns": ["*"], "enabled": false},
           {
             "enabled": true,
             "matchPackageNames": [
               "@walletconnect/ethereum-provider",
               "@walletconnect/universal-provider",
               "@walletconnect/utils",
               "@wagmi/core",
               "wagmi",
               "@wagmi/connectors",
               "viem",
               "ethers",
               "@solana/web3.js",
               "@web3modal/{/,}**"
             ],
             "matchPackagePrefixes": ["@web3modal/"],
             "prPriority": 10
           }
         ]
       },
       "newConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": [
           "config:best-practices",
           ":prConcurrentLimit10",
           ":prHourlyLimit2",
           ":semanticCommits",
           ":semanticCommitScope(deps)"
         ],
         "rebaseWhen": "conflicted",
         "packageRules": [
           {"enabled": false, "matchPackageNames": ["*"]},
           {
             "enabled": true,
             "matchPackageNames": [
               "@walletconnect/ethereum-provider",
               "@walletconnect/universal-provider",
               "@walletconnect/utils",
               "@wagmi/core",
               "wagmi",
               "@wagmi/connectors",
               "viem",
               "ethers",
               "@solana/web3.js",
               "@web3modal/{/,}**"
             ],
             "prPriority": 10
           }
         ]
       }
```