### PR TITLE
chore: fix renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,15 @@
     ":semanticCommitScope(deps)"
   ],
   "rebaseWhen": "conflicted",
-  "includePaths": ["examples/**"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
The previous PR (https://github.com/WalletConnect/web3modal/pull/2673) used `includePaths` but this resulted in ignoring all paths that weren't `examples`.

Instead overriding the [default `ignorePaths`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) to not include `examples` from the ignore list.