### PR TITLE
chore: Web3Modal -> AppKit

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F64B Feature Request"
-description: 'Want us to add something to Web3Modal?'
+description: 'Want us to add something to AppKit?'
 title: '[feature] '
 labels: ['feature-request', 'needs review']
 body:

--- a/apps/demo/app/layout.tsx
+++ b/apps/demo/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import localFont from 'next/font/local'
 import '@/styles/globals.css'
-import Web3ModalProvider from '@/context/Web3Modal'
+import AppKitProvider from '@/context/AppKit'
 
 const abcDiatype = localFont({
   src: [
@@ -18,12 +18,12 @@ const abcDiatype = localFont({
 })
 
 export const metadata: Metadata = {
-  title: 'Web3Modal | Demo',
+  title: 'AppKit | Demo',
   description:
-    'Web3Modal is an elegantly simple yet powerful library that helps you manage your multi-chain wallet connection flows, all in one place.',
+    'AppKit is an elegantly simple yet powerful library that helps you manage your multi-chain wallet connection flows, all in one place.',
   openGraph: {
     description:
-      'Your on-ramp to web3 multichain. Web3Modal is a versatile library that makes it super easy to connect users with your Dapp and start interacting with the blockchain.'
+      'Your on-ramp to web3 multichain. AppKit is a versatile library that makes it super easy to connect users with your Dapp and start interacting with the blockchain.'
   }
 }
 
@@ -35,7 +35,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={abcDiatype.className}>
-        <Web3ModalProvider>{children}</Web3ModalProvider>
+        <AppKitProvider>{children}</AppKitProvider>
       </body>
     </html>
   )

--- a/apps/demo/app/page.tsx
+++ b/apps/demo/app/page.tsx
@@ -8,7 +8,7 @@ import { motion } from 'framer-motion'
 import { VARIANTS } from '@/utils/constants'
 
 export default function Home() {
-  // Web3Modal Demo
+  // AppKit Demo
   return (
     <motion.main
       variants={VARIANTS}

--- a/apps/demo/components/ConfigSection.tsx
+++ b/apps/demo/components/ConfigSection.tsx
@@ -53,7 +53,7 @@ export default function ConfigSection() {
       >
         <div className="flex-grow px-12 py-8">
           <motion.h1 variants={VARIANTS} className="text-xl font-bold">
-            Build Your Own Web3Modal
+            Build Your Own AppKit
           </motion.h1>
           <motion.p variants={VARIANTS} className="text-[var(--navy-400)] text-sm mt-1 mb-6">
             Modify the configuration to suit your needs. You can copy the config and use it in your

--- a/apps/demo/components/NavSection.tsx
+++ b/apps/demo/components/NavSection.tsx
@@ -12,12 +12,12 @@ export default function NavSection() {
         <Image
           src={W3mLogo}
           placeholder="blur"
-          alt="Web3Modal Logo"
+          alt="AppKit Logo"
           width={40}
           height={40}
           className="rounded-lg"
         />
-        <span className="pt-0.5">Web3Modal</span>
+        <span className="pt-0.5">AppKit</span>
       </motion.a>
     </nav>
   )

--- a/apps/demo/components/ViewSection.tsx
+++ b/apps/demo/components/ViewSection.tsx
@@ -13,7 +13,7 @@ export default function ViewSection() {
       variants={VARIANTS}
       className="bg-white relative h-[36rem] w-96 grid place-items-center rounded-3xl text-xl shadow-slate-900/5 shadow-lg border-slate-200 border text-center p-8"
     >
-      <p className="absolute top-0 ml-auto py-8 opacity-50 text-sm">Hopefully Web3Modal here lol</p>
+      <p className="absolute top-0 ml-auto py-8 opacity-50 text-sm">Hopefully AppKit here lol</p>
       <div className="w-full">
         <p className="flex justify-between">
           Email:

--- a/apps/demo/context/AppKit.tsx
+++ b/apps/demo/context/AppKit.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import React from 'react'
+
+export default function AppKitProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/demo/context/Web3Modal.tsx
+++ b/apps/demo/context/Web3Modal.tsx
@@ -1,7 +1,0 @@
-'use client'
-
-import React from 'react'
-
-export default function Web3ModalProvider({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
-}

--- a/apps/laboratory/.env.example
+++ b/apps/laboratory/.env.example
@@ -2,7 +2,7 @@
 NEXT_PUBLIC_PROJECT_ID=""
 # See 1password for `NEXT_AUTH_SECRET`
 NEXTAUTH_SECRET=""
-# See 1password for `Mailsac Web3Modal API Key`
+# See 1password for `Mailsac AppKit API Key`
 MAILSAC_API_KEY=""
 # Only needed when overriding default next-auth URL
 # NEXTAUTH_URL=""

--- a/apps/laboratory/src/components/AppKitButtons.tsx
+++ b/apps/laboratory/src/components/AppKitButtons.tsx
@@ -1,10 +1,10 @@
 import { Stack, Card, CardHeader, Heading, CardBody, Box, StackDivider } from '@chakra-ui/react'
 
-export function Web3ModalButtons() {
+export function AppKitButtons() {
   return (
     <Card marginTop={20}>
       <CardHeader>
-        <Heading size="md">Web3Modal Interactions</Heading>
+        <Heading size="md">AppKit Interactions</Heading>
       </CardHeader>
 
       <CardBody>

--- a/apps/laboratory/src/components/AppKitInfo.tsx
+++ b/apps/laboratory/src/components/AppKitInfo.tsx
@@ -11,13 +11,13 @@ import {
   Text
 } from '@chakra-ui/react'
 
-type Web3ModalInfoProps = {
+type AppKitInfoProps = {
   address?: string
   chainId?: number
   clientId: string | null
 }
 
-export function Web3ModalInfo({ address, chainId, clientId }: Web3ModalInfoProps) {
+export function AppKitInfo({ address, chainId, clientId }: AppKitInfoProps) {
   return (
     <Card marginTop={10} marginBottom={10}>
       <CardHeader>

--- a/apps/laboratory/src/components/Ethers/EthersModalInfo.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersModalInfo.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useWeb3ModalAccount, useWeb3ModalProvider } from '@web3modal/ethers/react'
 import EthereumProvider from '@walletconnect/ethereum-provider'
 
-import { Web3ModalInfo } from '../Web3ModalInfo'
+import { AppKitInfo } from '../AppKitInfo'
 
 export function EthersModalInfo() {
   const { isConnected, address, chainId } = useWeb3ModalAccount()
@@ -28,6 +28,6 @@ export function EthersModalInfo() {
   }, [])
 
   return ready && isConnected ? (
-    <Web3ModalInfo address={address} chainId={chainId} clientId={clientId} />
+    <AppKitInfo address={address} chainId={chainId} clientId={clientId} />
   ) : null
 }

--- a/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiModalInfo.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import EthereumProvider from '@walletconnect/ethereum-provider'
 
 import { useAccount } from 'wagmi'
-import { Web3ModalInfo } from '../Web3ModalInfo'
+import { AppKitInfo } from '../AppKitInfo'
 
 export function WagmiModalInfo() {
   const { isConnected, address, chainId, connector } = useAccount()
@@ -23,7 +23,5 @@ export function WagmiModalInfo() {
     getClientId().then(setClientId)
   }, [connector])
 
-  return isConnected ? (
-    <Web3ModalInfo address={address} chainId={chainId} clientId={clientId} />
-  ) : null
+  return isConnected ? <AppKitInfo address={address} chainId={chainId} clientId={clientId} /> : null
 }

--- a/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
@@ -13,7 +13,7 @@ export function WagmiSignMessageTest() {
 
   async function onSignMessage() {
     try {
-      const sig = await signMessageAsync({ message: 'Hello Web3Modal!' })
+      const sig = await signMessageAsync({ message: 'Hello AppKit!' })
       setSignature(sig)
       toast({
         title: ConstantsUtil.SigningSucceededToastTitle,

--- a/apps/laboratory/src/pages/library/ethers-all-internal.tsx
+++ b/apps/laboratory/src/pages/library/ethers-all-internal.tsx
@@ -3,7 +3,7 @@ import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersTests } from '../../components/Ethers/EthersTests'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { siweConfig } from '../../utils/SiweUtils'
 import { SiweData } from '../../components/Siwe/SiweData'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
@@ -32,7 +32,7 @@ ThemeStore.setModal(modal)
 export default function Ethers() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <EthersModalInfo />
       <SiweData />
       <EthersTests />

--- a/apps/laboratory/src/pages/library/ethers-all.tsx
+++ b/apps/laboratory/src/pages/library/ethers-all.tsx
@@ -3,7 +3,7 @@ import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersTests } from '../../components/Ethers/EthersTests'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { siweConfig } from '../../utils/SiweUtils'
 import { SiweData } from '../../components/Siwe/SiweData'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
@@ -31,7 +31,7 @@ ThemeStore.setModal(modal)
 export default function Ethers() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <EthersModalInfo />
       <SiweData />
       <EthersTests />

--- a/apps/laboratory/src/pages/library/ethers-email.tsx
+++ b/apps/laboratory/src/pages/library/ethers-email.tsx
@@ -3,7 +3,7 @@ import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { EthersTests } from '../../components/Ethers/EthersTests'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { EthersModalInfo } from '../../components/Ethers/EthersModalInfo'
 
 const modal = createWeb3Modal({
@@ -28,7 +28,7 @@ ThemeStore.setModal(modal)
 export default function Ethers() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <EthersModalInfo />
       <EthersTests />
     </>

--- a/apps/laboratory/src/pages/library/ethers-siwe.tsx
+++ b/apps/laboratory/src/pages/library/ethers-siwe.tsx
@@ -1,6 +1,6 @@
 import { SiweData } from '../../components/Siwe/SiweData'
 import { EthersTests } from '../../components/Ethers/EthersTests'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
@@ -26,7 +26,7 @@ ThemeStore.setModal(modal)
 export default function EthersSiwe() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <EthersModalInfo />
       <SiweData />
       <EthersTests />

--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -1,5 +1,5 @@
 import { EthersTests } from '../../components/Ethers/EthersTests'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { createWeb3Modal, defaultConfig } from '@web3modal/ethers/react'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { EthersConstants } from '../../utils/EthersConstants'
@@ -27,7 +27,7 @@ ThemeStore.setModal(modal)
 export default function Ethers() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <EthersModalInfo />
       <EthersTests />
     </>

--- a/apps/laboratory/src/pages/library/external.tsx
+++ b/apps/laboratory/src/pages/library/external.tsx
@@ -2,7 +2,7 @@ import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { WagmiProvider, createConfig, http } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
@@ -44,7 +44,7 @@ export default function Wagmi() {
   return ready ? (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>

--- a/apps/laboratory/src/pages/library/solana.tsx
+++ b/apps/laboratory/src/pages/library/solana.tsx
@@ -2,7 +2,7 @@ import { createWeb3Modal, defaultSolanaConfig } from '@web3modal/solana/react'
 
 import { ThemeStore } from '../../utils/StoreUtil'
 import { solana, solanaDevnet, solanaTestnet } from '../../utils/ChainsUtil'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { SolanaTests } from '../../components/Solana/SolanaTests'
 import { SolflareWalletAdapter } from '@solana/wallet-adapter-wallets'
@@ -33,7 +33,7 @@ ThemeStore.setModal(modal)
 export default function Solana() {
   return (
     <>
-      <Web3ModalButtons />
+      <AppKitButtons />
       <SolanaTests />
     </>
   )

--- a/apps/laboratory/src/pages/library/wagmi-all-internal.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-all-internal.tsx
@@ -2,7 +2,7 @@ import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -38,7 +38,7 @@ export default function Wagmi() {
   return ready ? (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <SiweData />
         <WagmiTests />

--- a/apps/laboratory/src/pages/library/wagmi-all.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-all.tsx
@@ -2,7 +2,7 @@ import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -37,7 +37,7 @@ export default function Wagmi() {
   return ready ? (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <SiweData />
         <WagmiTests />

--- a/apps/laboratory/src/pages/library/wagmi-email.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-email.tsx
@@ -2,7 +2,7 @@ import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
@@ -34,7 +34,7 @@ export default function Wagmi() {
   return ready ? (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>

--- a/apps/laboratory/src/pages/library/wagmi-permissions-async.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-permissions-async.tsx
@@ -1,7 +1,7 @@
 import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -37,7 +37,7 @@ export default function Wagmi() {
     <WagmiProvider config={wagmiEmailConfig}>
       <QueryClientProvider client={queryClient}>
         <WagmiPermissionsAsyncProvider>
-          <Web3ModalButtons />
+          <AppKitButtons />
           <WagmiPermissionsAsyncTest />
         </WagmiPermissionsAsyncProvider>
       </QueryClientProvider>

--- a/apps/laboratory/src/pages/library/wagmi-permissions-sync.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-permissions-sync.tsx
@@ -1,7 +1,7 @@
 import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -37,7 +37,7 @@ export default function Wagmi() {
     <WagmiProvider config={wagmiEmailConfig}>
       <QueryClientProvider client={queryClient}>
         <WagmiPermissionsSyncProvider>
-          <Web3ModalButtons />
+          <AppKitButtons />
           <WagmiPermissionsSyncTest />
         </WagmiPermissionsSyncProvider>
       </QueryClientProvider>

--- a/apps/laboratory/src/pages/library/wagmi-siwe.tsx
+++ b/apps/laboratory/src/pages/library/wagmi-siwe.tsx
@@ -1,7 +1,7 @@
 import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -28,7 +28,7 @@ export default function Wagmi() {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <SiweData />
         <WagmiTests />

--- a/apps/laboratory/src/pages/library/wagmi.tsx
+++ b/apps/laboratory/src/pages/library/wagmi.tsx
@@ -1,7 +1,7 @@
 import { createWeb3Modal } from '@web3modal/wagmi/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiProvider } from 'wagmi'
-import { Web3ModalButtons } from '../../components/Web3ModalButtons'
+import { AppKitButtons } from '../../components/AppKitButtons'
 import { WagmiTests } from '../../components/Wagmi/WagmiTests'
 import { ThemeStore } from '../../utils/StoreUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
@@ -28,7 +28,7 @@ export default function Wagmi() {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <Web3ModalButtons />
+        <AppKitButtons />
         <WagmiModalInfo />
         <WagmiTests />
       </QueryClientProvider>

--- a/apps/laboratory/src/utils/ConnectorUtil.ts
+++ b/apps/laboratory/src/utils/ConnectorUtil.ts
@@ -12,7 +12,7 @@ export function externalTestConnector() {
 
   return createConnector<() => Record<string, never>, Properties>(() => ({
     id: 'externalTestConnector',
-    name: 'Web3Modal external',
+    name: 'AppKit external',
     type: 'externalTestConnector',
 
     async connect(options: ConnectOptions = {}) {

--- a/apps/laboratory/tests/README.md
+++ b/apps/laboratory/tests/README.md
@@ -9,7 +9,7 @@ We use Playwright as our functional test runner. It's configured to try multiple
 
 - Make sure your `.env.local` is set up (see `.env.example` for reference)
 - Run `pnpm playwright:install` to install the browsers required to run the tests
-- Build Web3Modal by running `pnpm build` in the root directory
+- Build AppKit by running `pnpm build` in the root directory
 
 ## Running Tests
 

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -230,7 +230,7 @@ export class ModalPage {
   async signatureRequestFrameShouldVisible(headerText: string) {
     await expect(
       this.page.frameLocator('#w3m-iframe').getByText(headerText),
-      'Web3Modal iframe should be visible'
+      'AppKit iframe should be visible'
     ).toBeVisible({
       timeout: 10000
     })

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -96,7 +96,7 @@ export class ModalValidator {
   async expectValidSignature(signature: `0x${string}`, address: `0x${string}`, chainId: number) {
     const isVerified = await verifySignature({
       address,
-      message: 'Hello Web3Modal!',
+      message: 'Hello AppKit!',
       signature,
       chainId
     })

--- a/examples/html-ethers5/src/main.js
+++ b/examples/html-ethers5/src/main.js
@@ -30,9 +30,9 @@ const chains = [
 
 const ethersConfig = defaultConfig({
   metadata: {
-    name: 'Web3Modal',
-    description: 'Web3Modal Laboratory',
-    url: 'https://web3modal.com',
+    name: 'AppKit',
+    description: 'AppKit Laboratory',
+    url: 'https://example.com',
     icons: ['https://avatars.githubusercontent.com/u/37784886']
   },
   defaultChainId: 1

--- a/examples/react-ethers/src/App.tsx
+++ b/examples/react-ethers/src/App.tsx
@@ -37,9 +37,9 @@ const chains = [
 
 const ethersConfig = defaultConfig({
   metadata: {
-    name: 'Web3Modal',
-    description: 'Web3Modal Laboratory',
-    url: 'https://web3modal.com',
+    name: 'AppKit',
+    description: 'AppKit Laboratory',
+    url: 'https://example.com',
     icons: ['https://avatars.githubusercontent.com/u/37784886']
   },
   defaultChainId: 1

--- a/examples/react-ethers5/src/App.tsx
+++ b/examples/react-ethers5/src/App.tsx
@@ -37,9 +37,9 @@ const chains = [
 
 const ethersConfig = defaultConfig({
   metadata: {
-    name: 'Web3Modal',
-    description: 'Web3Modal Laboratory',
-    url: 'https://web3modal.com',
+    name: 'AppKit',
+    description: 'AppKit Laboratory',
+    url: 'https://example.com',
     icons: ['https://avatars.githubusercontent.com/u/37784886']
   },
   defaultChainId: 1

--- a/examples/react-solana/src/App.tsx
+++ b/examples/react-solana/src/App.tsx
@@ -49,8 +49,8 @@ const solanaConfig = defaultSolanaConfig({
   chains: chains,
   projectId,
   metadata: {
-    name: 'Web3Modal React Example',
-    description: 'Web3Modal React Example',
+    name: 'AppKit React Example',
+    description: 'AppKit React Example',
     url: '',
     icons: []
   }

--- a/examples/react-wagmi/src/App.tsx
+++ b/examples/react-wagmi/src/App.tsx
@@ -24,8 +24,8 @@ const wagmiConfig = defaultWagmiConfig({
   chains: [mainnet, arbitrum],
   projectId,
   metadata: {
-    name: 'Web3Modal React Example',
-    description: 'Web3Modal React Example',
+    name: 'AppKit React Example',
+    description: 'AppKit React Example',
     url: '',
     icons: []
   }

--- a/examples/vue-ethers5/src/App.vue
+++ b/examples/vue-ethers5/src/App.vue
@@ -38,9 +38,9 @@ const chains = [
 
 const ethersConfig = defaultConfig({
   metadata: {
-    name: 'Web3Modal',
-    description: 'Web3Modal Laboratory',
-    url: 'https://web3modal.com',
+    name: 'AppKit',
+    description: 'AppKit Laboratory',
+    url: 'https://example.com',
     icons: ['https://avatars.githubusercontent.com/u/37784886']
   },
   defaultChainId: 1

--- a/examples/vue-solana/src/App.vue
+++ b/examples/vue-solana/src/App.vue
@@ -51,8 +51,8 @@ const solanaConfig = defaultSolanaConfig({
   chains: chains,
   projectId,
   metadata: {
-    name: 'Web3Modal React Example',
-    description: 'Web3Modal React Example',
+    name: 'AppKit React Example',
+    description: 'AppKit React Example',
     url: '',
     icons: []
   }

--- a/examples/vue-wagmi/src/App.vue
+++ b/examples/vue-wagmi/src/App.vue
@@ -21,8 +21,8 @@ const wagmiConfig = defaultWagmiConfig({
   chains,
   projectId,
   metadata: {
-    name: 'Web3Modal Vue Example',
-    description: 'Web3Modal Vue Example',
+    name: 'AppKit Vue Example',
+    description: 'AppKit Vue Example',
     url: '',
     icons: [],
     verifyUrl: ''

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@
 
 #### 🔗 [Website](https://web3modal.com)
 
-# Web3Modal
+# AppKit
 
-Your on-ramp to web3 multichain. Web3Modal is a versatile library that makes it super easy to connect users with your Dapp and start interacting with the blockchain.
+Your on-ramp to web3 multichain. AppKit is a versatile library that makes it super easy to connect users with your Dapp and start interacting with the blockchain.
 
 <p align="center">
   <img src="./.github/assets/header.png" alt="" border="0">


### PR DESCRIPTION
Renames various places of "Web3Modal" to "AppKit" following the rebrand, without breaking the SDKs.