### PR TITLE
refactor: export missing type defs from siwe package

### DIFF
--- a/packages/siwe/exports/index.ts
+++ b/packages/siwe/exports/index.ts
@@ -1,10 +1,4 @@
-import type {
-  SIWEConfig,
-  SIWESession,
-  SIWECreateMessageArgs,
-  SIWEVerifyMessageArgs,
-  SIWEClientMethods
-} from '../core/utils/TypeUtils.js'
+import type { SIWEConfig } from '../core/utils/TypeUtils.js'
 import { Web3ModalSIWEClient } from '../src/client.js'
 export {
   getAddressFromMessage,
@@ -13,15 +7,9 @@ export {
 } from '../core/helpers/index.js'
 export { formatMessage, getDidChainId, getDidAddress } from '@walletconnect/utils'
 export { SIWEController, type SIWEControllerClient } from '../core/controller/SIWEController.js'
+export * from '../core/utils/TypeUtils.js'
 
-export type {
-  Web3ModalSIWEClient,
-  SIWEConfig,
-  SIWESession,
-  SIWECreateMessageArgs,
-  SIWEVerifyMessageArgs,
-  SIWEClientMethods
-}
+export type { Web3ModalSIWEClient }
 
 export function createSIWEConfig(siweConfig: SIWEConfig) {
   return new Web3ModalSIWEClient(siweConfig)


### PR DESCRIPTION
# Description

In our SIWE package, we are exporting the type definitions but this is handled manually by importing them all and exporting again. This might lead to missing some type definitions to be exported, like we did for `SIWEMessageArgs`. This PR introducing slight improvements to SIWE type exports.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
