### PR TITLE
fix: ethers signMessage test message

### DIFF
--- a/apps/laboratory/src/components/Ethers/EthersSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersSignMessageTest.tsx
@@ -18,7 +18,7 @@ export function EthersSignMessageTest() {
       }
       const provider = new BrowserProvider(walletProvider, chainId)
       const signer = new JsonRpcSigner(provider, address)
-      const sig = await signer?.signMessage('Hello Web3Modal!')
+      const sig = await signer?.signMessage('Hello AppKit!')
       setSignature(sig)
       toast({
         title: ConstantsUtil.SigningSucceededToastTitle,

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -86,7 +86,7 @@ emailTest('it should switch network and sign', async () => {
   await validator.expectAcceptedSign()
 })
 
-emailTest.only('it should show loading on page refresh', async () => {
+emailTest('it should show loading on page refresh', async () => {
   await page.page.reload()
   await validator.expectConnectButtonLoading()
 })


### PR DESCRIPTION
# Description

- Ethers was sending "Hello Web3Modal!" instead of "Hello AppKit!"

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
