### PR TITLE
fix: defaultChain option setting to base

### DIFF
--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -14,9 +14,9 @@ const modal = createWeb3Modal({
     coinbasePreference: 'smartWalletOnly'
   }),
   chains: EthersConstants.chains,
+  defaultChain: EthersConstants.chains[1],
   projectId: ConstantsUtil.ProjectId,
   enableAnalytics: true,
-  defaultChain: EthersConstants.chains[1],
   metadata: ConstantsUtil.Metadata,
   termsConditionsUrl: 'https://walletconnect.com/terms',
   privacyPolicyUrl: 'https://walletconnect.com/privacy',

--- a/apps/laboratory/src/pages/library/ethers.tsx
+++ b/apps/laboratory/src/pages/library/ethers.tsx
@@ -16,6 +16,7 @@ const modal = createWeb3Modal({
   chains: EthersConstants.chains,
   projectId: ConstantsUtil.ProjectId,
   enableAnalytics: true,
+  defaultChain: EthersConstants.chains[1],
   metadata: ConstantsUtil.Metadata,
   termsConditionsUrl: 'https://walletconnect.com/terms',
   privacyPolicyUrl: 'https://walletconnect.com/privacy',

--- a/apps/laboratory/src/pages/library/ethers5.tsx
+++ b/apps/laboratory/src/pages/library/ethers5.tsx
@@ -13,6 +13,7 @@ const modal = createWeb3Modal({
     chains: EthersConstants.chains,
     coinbasePreference: 'smartWalletOnly'
   }),
+  defaultChain: EthersConstants.chains[0],
   chains: EthersConstants.chains,
   projectId: ConstantsUtil.ProjectId,
   enableAnalytics: true,

--- a/apps/laboratory/src/pages/library/solana.tsx
+++ b/apps/laboratory/src/pages/library/solana.tsx
@@ -19,6 +19,7 @@ const modal = createWeb3Modal({
   solanaConfig,
   projectId: ConstantsUtil.ProjectId,
   metadata: ConstantsUtil.Metadata,
+  defaultChain: solana,
   chains,
   enableAnalytics: false,
   termsConditionsUrl: 'https://walletconnect.com/terms',

--- a/apps/laboratory/src/pages/library/wagmi.tsx
+++ b/apps/laboratory/src/pages/library/wagmi.tsx
@@ -7,6 +7,7 @@ import { ThemeStore } from '../../utils/StoreUtil'
 import { getWagmiConfig } from '../../utils/WagmiConstants'
 import { ConstantsUtil } from '../../utils/ConstantsUtil'
 import { WagmiModalInfo } from '../../components/Wagmi/WagmiModalInfo'
+import { mainnet } from 'viem/chains'
 
 const queryClient = new QueryClient()
 
@@ -14,6 +15,7 @@ const wagmiConfig = getWagmiConfig('default')
 
 const modal = createWeb3Modal({
   wagmiConfig,
+  defaultChain: mainnet,
   projectId: ConstantsUtil.ProjectId,
   enableAnalytics: true,
   metadata: ConstantsUtil.Metadata,

--- a/packages/base/src/client.ts
+++ b/packages/base/src/client.ts
@@ -209,10 +209,6 @@ export class AppKit {
     NetworkController.setCaipNetwork(caipNetwork)
   }
 
-  public setActiveCaipNetwork: (typeof NetworkController)['setCaipNetwork'] = caipNetwork => {
-    NetworkController.setActiveCaipNetwork(caipNetwork)
-  }
-
   public getCaipNetwork = () => NetworkController.state.caipNetwork
 
   public setRequestedCaipNetworks: (typeof NetworkController)['setRequestedCaipNetworks'] = (

--- a/packages/base/utils/TypesUtil.ts
+++ b/packages/base/utils/TypesUtil.ts
@@ -8,56 +8,57 @@ import type {
 } from '@web3modal/core'
 import type { SIWEControllerClient, Web3ModalSIWEClient } from '@web3modal/siwe'
 
-export type AppKitOptions = OptionsControllerState & {
-  /**
-   * Adapter array to be used by the AppKit.
-   * @default []
-   */
-  adapters?: ChainAdapter[]
-  /**
-   * Sign In With Ethereum configuration object.
-   * @default undefined
-   * @see https://docs.walletconnect.com/appkit/react/core/siwe#configure-your-siwe-client
-   */
-  siweConfig?: Web3ModalSIWEClient
-  /**
-   * Theme mode configuration flag. By default themeMode option will be set to user system settings.
-   * @default `system`
-   * @type `dark` | `light`
-   * @see https://docs.walletconnect.com/appkit/react/core/theming
-   */
-  themeMode?: ThemeMode
-  /**
-   * Theme variable configuration object.
-   * @default undefined
-   * @see https://docs.walletconnect.com/appkit/react/core/theming#themevariables
-   */
-  themeVariables?: ThemeVariables
-  /**
-   * Allow users to switch to an unsupported chain.
-   * @see https://docs.walletconnect.com/appkit/react/core/options#allowunsupportedchain
-   */
-  allowUnsupportedChain?: NetworkControllerState['allowUnsupportedChain']
-  /**
-   * You can set a desired chain for the initial connection:
-   * @see https://docs.walletconnect.com/appkit/react/core/options#defaultchain
-   */
-  defaultChain?: NetworkControllerState['caipNetwork']
-  /**
-   * Add or override the modal's network images.
-   * @see https://docs.walletconnect.com/appkit/react/core/options#chainimages
-   */
-  chainImages?: Record<number | string, string>
-  /**
-   * Set or override the images of any connector. The key of each property must match the id of the connector.
-   * @see https://docs.walletconnect.com/appkit/react/core/options#connectorimages
-   */
-  connectorImages?: Record<string, string>
-  /**
-   * Tokens for AppKit to show the user's balance of.
-   * @see https://docs.walletconnect.com/appkit/react/core/options#tokens
-   */
-  tokens?: Record<number, Token>
-  // -- Internal options ---------------------------------- //
-  siweControllerClient?: SIWEControllerClient
-}
+export type AppKitOptions<ChainType = NetworkControllerState['caipNetwork']> =
+  OptionsControllerState & {
+    /**
+     * Adapter array to be used by the AppKit.
+     * @default []
+     */
+    adapters?: ChainAdapter[]
+    /**
+     * Sign In With Ethereum configuration object.
+     * @default undefined
+     * @see https://docs.walletconnect.com/appkit/react/core/siwe#configure-your-siwe-client
+     */
+    siweConfig?: Web3ModalSIWEClient
+    /**
+     * Theme mode configuration flag. By default themeMode option will be set to user system settings.
+     * @default `system`
+     * @type `dark` | `light`
+     * @see https://docs.walletconnect.com/appkit/react/core/theming
+     */
+    themeMode?: ThemeMode
+    /**
+     * Theme variable configuration object.
+     * @default undefined
+     * @see https://docs.walletconnect.com/appkit/react/core/theming#themevariables
+     */
+    themeVariables?: ThemeVariables
+    /**
+     * Allow users to switch to an unsupported chain.
+     * @see https://docs.walletconnect.com/appkit/react/core/options#allowunsupportedchain
+     */
+    allowUnsupportedChain?: NetworkControllerState['allowUnsupportedChain']
+    /**
+     * You can set a desired chain for the initial connection:
+     * @see https://docs.walletconnect.com/appkit/react/core/options#defaultchain
+     */
+    defaultChain?: ChainType
+    /**
+     * Add or override the modal's network images.
+     * @see https://docs.walletconnect.com/appkit/react/core/options#chainimages
+     */
+    chainImages?: Record<number | string, string>
+    /**
+     * Set or override the images of any connector. The key of each property must match the id of the connector.
+     * @see https://docs.walletconnect.com/appkit/react/core/options#connectorimages
+     */
+    connectorImages?: Record<string, string>
+    /**
+     * Tokens for AppKit to show the user's balance of.
+     * @see https://docs.walletconnect.com/appkit/react/core/options#tokens
+     */
+    tokens?: Record<number, Token>
+    // -- Internal options ---------------------------------- //
+    siweControllerClient?: SIWEControllerClient
+  }

--- a/packages/core/src/controllers/EnsController.ts
+++ b/packages/core/src/controllers/EnsController.ts
@@ -10,6 +10,7 @@ import { NetworkController } from './NetworkController.js'
 import { NetworkUtil } from '@web3modal/common'
 import { EnsUtil } from '../utils/EnsUtil.js'
 import { ConstantsUtil } from '@web3modal/common'
+import { ChainController } from './ChainController.js'
 
 // -- Types --------------------------------------------- //
 type Suggestion = {
@@ -142,7 +143,10 @@ export const EnsController = {
         message
       })
 
-      AccountController.setProfileName(`${name}${ConstantsUtil.WC_NAME_SUFFIX}`, network.chain)
+      AccountController.setProfileName(
+        `${name}${ConstantsUtil.WC_NAME_SUFFIX}`,
+        ChainController.state.activeChain
+      )
       RouterController.replace('RegisterAccountNameSuccess')
     } catch (e) {
       const errorMessage = this.parseEnsApiError(e, `Error registering name ${name}`)

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -78,7 +78,7 @@ export const NetworkController = {
 
   setDefaultCaipNetwork(caipNetwork: NetworkControllerState['caipNetwork']) {
     if (caipNetwork) {
-      ChainController.setCaipNetwork(caipNetwork.chain, caipNetwork)
+      ChainController.setCaipNetwork(caipNetwork.chain, caipNetwork, true)
       ChainController.setChainNetworkData(caipNetwork.chain, { isDefaultCaipNetwork: true })
       PublicStateController.set({ selectedNetworkId: caipNetwork.id })
     }

--- a/packages/ethers/exports/index.ts
+++ b/packages/ethers/exports/index.ts
@@ -17,11 +17,13 @@ export function createWeb3Modal(options: EthersAppKitOptions) {
   const ethersAdapter = new EVMEthersClient({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
 
   return new AppKit({
     ...options,
+    defaultChain: ethersAdapter.defaultChain,
     adapters: [ethersAdapter],
     sdkType: 'w3m',
     sdkVersion: `html-ethers-${ConstantsUtil.VERSION}`

--- a/packages/ethers/exports/index.ts
+++ b/packages/ethers/exports/index.ts
@@ -2,6 +2,7 @@ import { AppKit } from '@web3modal/base'
 import type { AppKitOptions } from '@web3modal/base'
 import { EVMEthersClient, type AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
+import { type Chain } from '@web3modal/scaffold-utils/ethers'
 
 // -- Types -------------------------------------------------------------
 export type { AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
@@ -10,7 +11,10 @@ export type { AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
 export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 
 // -- Setup -------------------------------------------------------------
-export type EthersAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type EthersAppKitOptions = Omit<
+  AppKitOptions<Chain>,
+  'adapters' | 'sdkType' | 'sdkVersion'
+> &
   AdapterOptions
 
 export function createWeb3Modal(options: EthersAppKitOptions) {

--- a/packages/ethers/exports/react.tsx
+++ b/packages/ethers/exports/react.tsx
@@ -4,7 +4,7 @@ import { AppKit } from '@web3modal/base'
 import type { AppKitOptions } from '@web3modal/base'
 import { EVMEthersClient, type AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
-import { EthersStoreUtil } from '@web3modal/scaffold-utils/ethers'
+import { EthersStoreUtil, type Chain } from '@web3modal/scaffold-utils/ethers'
 import { getWeb3Modal } from '@web3modal/base/utils/library/react'
 import { useSnapshot } from 'valtio'
 import type { Eip1193Provider } from 'ethers'
@@ -16,7 +16,10 @@ export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 let appkit: AppKit | undefined = undefined
 let ethersAdapter: EVMEthersClient | undefined = undefined
 
-export type EthersAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type EthersAppKitOptions = Omit<
+  AppKitOptions<Chain>,
+  'adapters' | 'sdkType' | 'sdkVersion'
+> &
   AdapterOptions
 
 export function createWeb3Modal(options: EthersAppKitOptions) {

--- a/packages/ethers/exports/react.tsx
+++ b/packages/ethers/exports/react.tsx
@@ -23,10 +23,12 @@ export function createWeb3Modal(options: EthersAppKitOptions) {
   ethersAdapter = new EVMEthersClient({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: ethersAdapter.defaultChain,
     adapters: [ethersAdapter],
     sdkType: 'w3m',
     sdkVersion: `react-ethers-${ConstantsUtil.VERSION}`

--- a/packages/ethers/exports/vue.ts
+++ b/packages/ethers/exports/vue.ts
@@ -2,6 +2,7 @@ import { AppKit } from '@web3modal/base'
 import type { AppKitOptions } from '@web3modal/base'
 import { EVMEthersClient, type AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
+import { type Chain } from '@web3modal/scaffold-utils/ethers'
 import { getWeb3Modal } from '@web3modal/base/utils/library/vue'
 import { onUnmounted, ref } from 'vue'
 import type { Eip1193Provider } from 'ethers'
@@ -13,7 +14,7 @@ export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 let appkit: AppKit | undefined = undefined
 let ethersAdapter: EVMEthersClient | undefined = undefined
 
-type EthersAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+type EthersAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions
 
 export function createWeb3Modal(options: EthersAppKitOptions) {

--- a/packages/ethers/exports/vue.ts
+++ b/packages/ethers/exports/vue.ts
@@ -20,10 +20,12 @@ export function createWeb3Modal(options: EthersAppKitOptions) {
   ethersAdapter = new EVMEthersClient({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: ethersAdapter.defaultChain,
     adapters: [ethersAdapter],
     sdkType: 'w3m',
     sdkVersion: `vue-ethers-${ConstantsUtil.VERSION}`

--- a/packages/ethers5/exports/index.ts
+++ b/packages/ethers5/exports/index.ts
@@ -2,6 +2,7 @@ import { AppKit } from '@web3modal/base'
 import type { AppKitOptions } from '@web3modal/base'
 import { EVMEthers5Client, type AdapterOptions } from '@web3modal/base/adapters/evm/ethers5'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
+import { type Chain } from '@web3modal/scaffold-utils/ethers'
 
 // -- Types -------------------------------------------------------------
 export type { AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
@@ -10,7 +11,7 @@ export type { AdapterOptions } from '@web3modal/base/adapters/evm/ethers'
 export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 
 // -- Setup -------------------------------------------------------------
-type EthersAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+type EthersAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions
 
 export function createWeb3Modal(options: EthersAppKitOptions) {

--- a/packages/ethers5/exports/index.ts
+++ b/packages/ethers5/exports/index.ts
@@ -17,11 +17,13 @@ export function createWeb3Modal(options: EthersAppKitOptions) {
   const ethers5Adapter = new EVMEthers5Client({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
 
   return new AppKit({
     ...options,
+    defaultChain: ethers5Adapter.defaultChain,
     adapters: [ethers5Adapter],
     sdkType: 'w3m',
     sdkVersion: `html-ethers5-${ConstantsUtil.VERSION}`

--- a/packages/ethers5/exports/react.tsx
+++ b/packages/ethers5/exports/react.tsx
@@ -23,10 +23,12 @@ export function createWeb3Modal(options: Ethers5AppKitOptions) {
   ethersAdapter = new EVMEthersClient({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: ethersAdapter.defaultChain,
     adapters: [ethersAdapter],
     sdkType: 'w3m',
     sdkVersion: `react-ethers5-${ConstantsUtil.VERSION}`

--- a/packages/ethers5/exports/react.tsx
+++ b/packages/ethers5/exports/react.tsx
@@ -8,6 +8,7 @@ import { EthersStoreUtil } from '@web3modal/scaffold-utils/ethers'
 import { getWeb3Modal } from '@web3modal/base/utils/library/react'
 import { useSnapshot } from 'valtio'
 import { ethers } from 'ethers'
+import { type Chain } from '@web3modal/scaffold-utils/ethers'
 
 // -- Configs -----------------------------------------------------------
 export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
@@ -16,7 +17,10 @@ export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 let appkit: AppKit | undefined = undefined
 let ethersAdapter: EVMEthersClient | undefined = undefined
 
-export type Ethers5AppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type Ethers5AppKitOptions = Omit<
+  AppKitOptions<Chain>,
+  'adapters' | 'sdkType' | 'sdkVersion'
+> &
   AdapterOptions
 
 export function createWeb3Modal(options: Ethers5AppKitOptions) {

--- a/packages/ethers5/exports/vue.ts
+++ b/packages/ethers5/exports/vue.ts
@@ -20,10 +20,12 @@ export function createWeb3Modal(options: EthersAppKitOptions) {
   ethersAdapter = new EVMEthersClient({
     ethersConfig: options.ethersConfig,
     siweConfig: options.siweConfig,
-    chains: options.chains
+    chains: options.chains,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: ethersAdapter.defaultChain,
     adapters: [ethersAdapter],
     sdkType: 'w3m',
     sdkVersion: `vue-ethers5-${ConstantsUtil.VERSION}`

--- a/packages/ethers5/exports/vue.ts
+++ b/packages/ethers5/exports/vue.ts
@@ -5,6 +5,7 @@ import { ConstantsUtil } from '@web3modal/scaffold-utils'
 import { getWeb3Modal } from '@web3modal/base/utils/library/vue'
 import { onUnmounted, ref } from 'vue'
 import { ethers } from 'ethers'
+import { type Chain } from '@web3modal/scaffold-utils/ethers'
 
 // -- Configs -----------------------------------------------------------
 export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
@@ -13,7 +14,7 @@ export { defaultConfig } from '@web3modal/base/adapters/evm/ethers'
 let appkit: AppKit | undefined = undefined
 let ethersAdapter: EVMEthersClient | undefined = undefined
 
-type EthersAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+type EthersAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions
 
 export function createWeb3Modal(options: EthersAppKitOptions) {

--- a/packages/solana/exports/index.ts
+++ b/packages/solana/exports/index.ts
@@ -11,7 +11,7 @@ export type { SolanaAppKitOptions }
 
 // -- Setup -------------------------------------------------------------
 export function createWeb3Modal(options: SolanaAppKitOptions) {
-  const wagmiAdapter = new SolanaWeb3JsClient({
+  const solanaAdapter = new SolanaWeb3JsClient({
     solanaConfig: options.solanaConfig,
     chains: options.chains,
     wallets: options.wallets,
@@ -21,8 +21,8 @@ export function createWeb3Modal(options: SolanaAppKitOptions) {
 
   return new AppKit({
     ...options,
-    defaultChain: wagmiAdapter.defaultChain,
-    adapters: [wagmiAdapter],
+    defaultChain: solanaAdapter.defaultChain,
+    adapters: [solanaAdapter],
     sdkType: 'w3m',
     sdkVersion: `html-solana-${ConstantsUtil.VERSION}`
   })

--- a/packages/solana/exports/index.ts
+++ b/packages/solana/exports/index.ts
@@ -15,11 +15,13 @@ export function createWeb3Modal(options: SolanaAppKitOptions) {
     solanaConfig: options.solanaConfig,
     chains: options.chains,
     wallets: options.wallets,
-    projectId: options.projectId
+    projectId: options.projectId,
+    defaultChain: options.defaultChain
   })
 
   return new AppKit({
     ...options,
+    defaultChain: wagmiAdapter.defaultChain,
     adapters: [wagmiAdapter],
     sdkType: 'w3m',
     sdkVersion: `html-solana-${ConstantsUtil.VERSION}`

--- a/packages/solana/exports/options.ts
+++ b/packages/solana/exports/options.ts
@@ -1,5 +1,9 @@
 import type { AppKitOptions } from '@web3modal/base'
 import type { Web3ModalClientOptions } from '@web3modal/base/adapters/solana/web3js'
+import { type Chain } from '@web3modal/scaffold-utils/solana'
 
-export type SolanaAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type SolanaAppKitOptions = Omit<
+  AppKitOptions<Chain>,
+  'adapters' | 'sdkType' | 'sdkVersion'
+> &
   Web3ModalClientOptions

--- a/packages/solana/exports/react.tsx
+++ b/packages/solana/exports/react.tsx
@@ -24,10 +24,12 @@ export function createWeb3Modal(options: SolanaAppKitOptions) {
     solanaConfig: options.solanaConfig,
     chains: options.chains,
     wallets: options.wallets,
-    projectId: options.projectId
+    projectId: options.projectId,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: solanaAdapter.defaultChain,
     adapters: [solanaAdapter],
     sdkType: 'w3m',
     sdkVersion: `react-solana-${ConstantsUtil.VERSION}`

--- a/packages/solana/exports/vue.ts
+++ b/packages/solana/exports/vue.ts
@@ -20,10 +20,12 @@ export function createWeb3Modal(options: SolanaAppKitOptions) {
     solanaConfig: options.solanaConfig,
     chains: options.chains,
     wallets: options.wallets,
-    projectId: options.projectId
+    projectId: options.projectId,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: solanaAdapter.defaultChain,
     adapters: [solanaAdapter],
     sdkType: 'w3m',
     sdkVersion: `vue-solana-${ConstantsUtil.VERSION}`

--- a/packages/wagmi/exports/index.ts
+++ b/packages/wagmi/exports/index.ts
@@ -20,11 +20,13 @@ export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 's
 export function createWeb3Modal(options: WagmiAppKitOptions) {
   const wagmiAdapter = new EVMWagmiClient({
     wagmiConfig: options.wagmiConfig,
-    siweConfig: options.siweConfig
+    siweConfig: options.siweConfig,
+    defaultChain: options.defaultChain
   })
 
   return new AppKit({
     ...options,
+    defaultChain: wagmiAdapter.defaultChain,
     adapters: [wagmiAdapter],
     sdkType: 'w3m',
     sdkVersion: `html-wagmi-${ConstantsUtil.VERSION}`

--- a/packages/wagmi/exports/index.ts
+++ b/packages/wagmi/exports/index.ts
@@ -2,6 +2,7 @@ import { AppKit } from '@web3modal/base'
 import type { AppKitOptions } from '@web3modal/base'
 import { EVMWagmiClient, type AdapterOptions } from '@web3modal/base/adapters/evm/wagmi'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
+import type { Chain } from 'viem'
 import type { Config } from 'wagmi'
 
 // -- Types -------------------------------------------------------------
@@ -14,7 +15,7 @@ export { authConnector } from '@web3modal/base/adapters/evm/wagmi'
 export { defaultWagmiConfig } from '@web3modal/base/adapters/evm/wagmi'
 
 // -- Setup -------------------------------------------------------------
-export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type WagmiAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions<Config>
 
 export function createWeb3Modal(options: WagmiAppKitOptions) {

--- a/packages/wagmi/exports/react/index.ts
+++ b/packages/wagmi/exports/react/index.ts
@@ -3,6 +3,7 @@ import type { AppKitOptions } from '@web3modal/base'
 import { EVMWagmiClient, type AdapterOptions } from '@web3modal/base/adapters/evm/wagmi'
 import { getWeb3Modal } from '@web3modal/base/utils/library/react'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
+import type { Chain } from 'viem'
 import type { Config } from 'wagmi'
 
 // -- Configs -----------------------------------------------------------
@@ -12,7 +13,7 @@ export { defaultWagmiConfig } from '@web3modal/base/adapters/evm/wagmi'
 let appkit: AppKit | undefined = undefined
 let wagmiAdapter: EVMWagmiClient | undefined = undefined
 
-export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type WagmiAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions<Config>
 
 export function createWeb3Modal(options: WagmiAppKitOptions) {

--- a/packages/wagmi/exports/react/index.ts
+++ b/packages/wagmi/exports/react/index.ts
@@ -18,10 +18,12 @@ export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 's
 export function createWeb3Modal(options: WagmiAppKitOptions) {
   wagmiAdapter = new EVMWagmiClient({
     wagmiConfig: options.wagmiConfig,
-    siweConfig: options.siweConfig
+    siweConfig: options.siweConfig,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: wagmiAdapter.defaultChain,
     adapters: [wagmiAdapter],
     sdkType: 'w3m',
     sdkVersion: `react-wagmi-${ConstantsUtil.VERSION}`

--- a/packages/wagmi/exports/vue.ts
+++ b/packages/wagmi/exports/vue.ts
@@ -4,6 +4,7 @@ import { EVMWagmiClient, type AdapterOptions } from '@web3modal/base/adapters/ev
 import { getWeb3Modal } from '@web3modal/base/utils/library/vue'
 import { ConstantsUtil } from '@web3modal/scaffold-utils'
 import type { Config } from '@wagmi/core'
+import type { Chain } from 'viem'
 
 // -- Configs -----------------------------------------------------------
 export { defaultWagmiConfig } from '@web3modal/base/adapters/evm/wagmi'
@@ -12,7 +13,7 @@ export { defaultWagmiConfig } from '@web3modal/base/adapters/evm/wagmi'
 let appkit: AppKit | undefined = undefined
 let wagmiAdapter: EVMWagmiClient | undefined = undefined
 
-export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 'sdkVersion'> &
+export type WagmiAppKitOptions = Omit<AppKitOptions<Chain>, 'adapters' | 'sdkType' | 'sdkVersion'> &
   AdapterOptions<Config>
 
 export function createWeb3Modal(options: WagmiAppKitOptions) {

--- a/packages/wagmi/exports/vue.ts
+++ b/packages/wagmi/exports/vue.ts
@@ -18,10 +18,12 @@ export type WagmiAppKitOptions = Omit<AppKitOptions, 'adapters' | 'sdkType' | 's
 export function createWeb3Modal(options: WagmiAppKitOptions) {
   wagmiAdapter = new EVMWagmiClient({
     wagmiConfig: options.wagmiConfig,
-    siweConfig: options.siweConfig
+    siweConfig: options.siweConfig,
+    defaultChain: options.defaultChain
   })
   appkit = new AppKit({
     ...options,
+    defaultChain: wagmiAdapter.defaultChain,
     adapters: [wagmiAdapter],
     sdkType: 'w3m',
     sdkVersion: `vue-wagmi-${ConstantsUtil.VERSION}`


### PR DESCRIPTION
# Description

We have different clients (wagmi|ethers|solana) and each have different type of chain object. In the old architecture, we were casting them to our internal `CaipNetwork` object and was using. While switching to new architecture, this logic is missed. 

It's required to pass the casted object to the AppKit from the adapters. This PR introduces changes to fix this issue by updating the backwards compatible packages' exports and pass `defaultChain` value to `AppKit` instance.

The reason we are doing this is that, inside of the adapters, the `defaultChain` value is turned to `CaipNetwork`, on the adapter's constructors, like the following:

```js
this.defaultChain = getCaipDefaultChain(defaultChain)
```

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
