### PR TITLE
chore: only upgrade ethers v6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,12 @@
     },
     {
       "enabled": true,
-      "matchPackageNames": ["ethers", "@solana/web3.js"]
+      "matchPackageNames": ["ethers"],
+      "matchCurrentVersion": ">=6.0.0"
+    },
+    {
+      "enabled": true,
+      "matchPackageNames": ["@solana/web3.js"]
     }
   ]
 }


### PR DESCRIPTION
# Description

Makes it so Renovate bot doesn't try to upgrade ethers v5 versions. Then we should be able to merge [this PR](https://github.com/WalletConnect/web3modal/pull/2434) properly

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
