### PR TITLE
fix: wagmi not disconnecting 

### DIFF
--- a/packages/base/adapters/evm/wagmi/client.ts
+++ b/packages/base/adapters/evm/wagmi/client.ts
@@ -71,8 +71,6 @@ export class EVMWagmiClient {
   // -- Private variables -------------------------------------------------------
   private appKit: AppKit | undefined = undefined
 
-  private hasSyncedConnectedAccount = false
-
   private wagmiConfig: AdapterOptions<Config>['wagmiConfig']
 
   // -- Public variables --------------------------------------------------------
@@ -455,11 +453,10 @@ export class EVMWagmiClient {
 
   private async syncAccount({
     address,
-    isConnected,
-    isDisconnected,
     chainId,
     connector,
-    addresses
+    addresses,
+    status
   }: Partial<
     Pick<
       GetAccountReturnType,
@@ -477,10 +474,9 @@ export class EVMWagmiClient {
     if (this.appKit?.getCaipAddress() === caipAddress) {
       return
     }
-
-    if (isConnected && address && chainId) {
-      this.syncNetwork(address, chainId, isConnected)
-      this.appKit?.setIsConnected(isConnected, this.chain)
+    if (status === 'connected' && address && chainId) {
+      this.syncNetwork(address, chainId, true)
+      this.appKit?.setIsConnected(true, this.chain)
       this.appKit?.setCaipAddress(caipAddress, this.chain)
       await Promise.all([
         this.syncProfile(address, chainId),
@@ -500,15 +496,11 @@ export class EVMWagmiClient {
           this.chain
         )
       }
-
-      this.hasSyncedConnectedAccount = true
-    } else if (isDisconnected && this.hasSyncedConnectedAccount) {
+    } else if (status === 'disconnected') {
       this.appKit?.resetAccount(this.chain)
       this.appKit?.resetWcConnection()
       this.appKit?.resetNetwork()
       this.appKit?.setAllAccounts([], this.chain)
-
-      this.hasSyncedConnectedAccount = false
     }
   }
 
@@ -535,9 +527,8 @@ export class EVMWagmiClient {
         } else {
           this.appKit?.setAddressExplorerUrl(undefined, this.chain)
         }
-        if (this.hasSyncedConnectedAccount) {
-          await this.syncBalance(address, chainId)
-        }
+
+        await this.syncBalance(address, chainId)
       }
     }
   }


### PR DESCRIPTION
# Description
- There was a rogue flag `hasSyncedConnectedAccount` which was not properly being set on time allowing for desyncs. 
- We were using unreliable `isConnected` and `isDisconnected` flags from wagmi. Replaced with more reliable `status` flag.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-921

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
