### PR TITLE
fix: impossible to press on send placeholder input on mobile

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-input-address/styles.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-address/styles.ts
@@ -31,6 +31,7 @@ export default css`
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+    z-index: 2;
   }
 
   .paste {

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/styles.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/styles.ts
@@ -19,7 +19,7 @@ export default css`
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    z-index: 1;
+    z-index: 3;
   }
 
   wui-button {


### PR DESCRIPTION
# Description

Currently it's almost impossible to press send address field on iOS. You have to click on borders / edges to be able to type on the input.

<img src="https://github.com/user-attachments/assets/7539b400-a9ed-4ad3-984e-844660be4325" alt="send-placeholder" width="230" height="500" />


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-932

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
