### PR TITLE
fix: logics to set default chain

### DIFF
--- a/apps/laboratory/tests/shared/utils/project.ts
+++ b/apps/laboratory/tests/shared/utils/project.ts
@@ -5,7 +5,7 @@ import { getLocalBravePath, BRAVE_LINUX_PATH } from '../constants/browsers'
 
 const availableDevices = getAvailableDevices()
 
-const LIBRARIES = ['ethers5'] as const
+const LIBRARIES = ['ethers5', 'ethers', 'wagmi', 'solana'] as const
 
 const PERMUTATIONS = availableDevices.flatMap(device =>
   LIBRARIES.map(library => ({ device, library }))

--- a/apps/laboratory/tests/shared/utils/project.ts
+++ b/apps/laboratory/tests/shared/utils/project.ts
@@ -5,7 +5,7 @@ import { getLocalBravePath, BRAVE_LINUX_PATH } from '../constants/browsers'
 
 const availableDevices = getAvailableDevices()
 
-const LIBRARIES = ['ethers5', 'ethers', 'wagmi', 'solana'] as const
+const LIBRARIES = ['ethers5'] as const
 
 const PERMUTATIONS = availableDevices.flatMap(device =>
   LIBRARIES.map(library => ({ device, library }))

--- a/examples/react-ethers5/src/App.tsx
+++ b/examples/react-ethers5/src/App.tsx
@@ -49,6 +49,7 @@ const ethersConfig = defaultConfig({
 createWeb3Modal({
   ethersConfig,
   chains,
+  defaultChain: chains[1],
   projectId,
   enableAnalytics: true,
   themeMode: 'light',

--- a/examples/react-solana/src/App.tsx
+++ b/examples/react-solana/src/App.tsx
@@ -60,6 +60,7 @@ createWeb3Modal({
   solanaConfig,
   projectId,
   themeMode: 'light',
+  defaultChain: chains[2],
   chains,
   wallets: [
     new HuobiWalletAdapter(),

--- a/examples/react-wagmi/src/App.tsx
+++ b/examples/react-wagmi/src/App.tsx
@@ -7,7 +7,7 @@ import {
   useWeb3ModalTheme
 } from '@web3modal/wagmi/react'
 import { WagmiProvider } from 'wagmi'
-import { arbitrum, mainnet } from 'wagmi/chains'
+import { arbitrum, mainnet, polygon } from 'wagmi/chains'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiHooks } from './WagmiHooks'
 
@@ -22,7 +22,7 @@ if (!projectId) {
 
 // 2. Create wagmiConfig
 const wagmiConfig = defaultWagmiConfig({
-  chains: [mainnet, arbitrum],
+  chains: [mainnet, polygon, arbitrum],
   projectId,
   metadata: {
     name: 'AppKit',
@@ -36,6 +36,7 @@ const wagmiConfig = defaultWagmiConfig({
 createWeb3Modal({
   wagmiConfig,
   projectId,
+  defaultChain: polygon,
   themeMode: 'light',
   themeVariables: {
     '--w3m-color-mix': '#00DCFF',

--- a/packages/base/adapters/evm/ethers/client.ts
+++ b/packages/base/adapters/evm/ethers/client.ts
@@ -149,10 +149,7 @@ export class EVMEthersClient implements ChainAdapter<EthersStoreUtilState, numbe
     this.ethersConfig = ethersConfig
     this.siweControllerClient = this.options?.siweConfig
     this.tokens = HelpersUtil.getCaipTokens(options.tokens)
-    this.defaultChain = {
-      ...EthersHelpersUtil.getCaipDefaultChain(defaultChain),
-      chain: CommonConstantsUtil.CHAIN.EVM
-    } as CaipNetwork
+    this.defaultChain = EthersHelpersUtil.getCaipDefaultChain(defaultChain)
     this.chains = chains
 
     this.networkControllerClient = {
@@ -524,6 +521,10 @@ export class EVMEthersClient implements ChainAdapter<EthersStoreUtilState, numbe
     this.options = options
     this.projectId = options.projectId
     this.metadata = this.ethersConfig.metadata
+
+    if (this.defaultChain) {
+      this.appKit?.setCaipNetwork(this.defaultChain)
+    }
 
     this.createProvider()
 

--- a/packages/base/adapters/evm/ethers5/client.ts
+++ b/packages/base/adapters/evm/ethers5/client.ts
@@ -130,10 +130,7 @@ export class EVMEthers5Client implements ChainAdapter<EthersStoreUtilState, numb
 
     this.ethersConfig = ethersConfig
     this.siweControllerClient = siweConfig
-    this.defaultChain = {
-      ...EthersHelpersUtil.getCaipDefaultChain(defaultChain),
-      chain: CommonConstantsUtil.CHAIN.EVM
-    } as CaipNetwork
+    this.defaultChain = EthersHelpersUtil.getCaipDefaultChain(defaultChain)
     this.tokens = HelpersUtil.getCaipTokens(tokens)
     this.chains = chains
 
@@ -409,6 +406,10 @@ export class EVMEthers5Client implements ChainAdapter<EthersStoreUtilState, numb
     this.options = options
     this.projectId = options.projectId
     this.metadata = this.ethersConfig.metadata
+
+    if (this.defaultChain) {
+      this.appKit?.setCaipNetwork(this.defaultChain)
+    }
 
     this.createProvider()
 

--- a/packages/base/adapters/evm/wagmi/client.ts
+++ b/packages/base/adapters/evm/wagmi/client.ts
@@ -551,6 +551,7 @@ export class EVMWagmiClient implements ChainAdapter {
       this.appKit?.setProfileName(null, this.chain)
     }
   }
+
   private async syncProfile(address: Hex, chainId: Chain['id']) {
     if (!this.appKit) {
       throw new Error('syncProfile - appKit is undefined')

--- a/packages/base/adapters/solana/web3js/client.ts
+++ b/packages/base/adapters/solana/web3js/client.ts
@@ -230,15 +230,13 @@ export class SolanaWeb3JsClient implements ChainAdapter<SolStoreUtilState, CaipN
       ...clientOptions.solanaConfig.auth
     })
 
-    const defaultChain = this.defaultChain
-
     if (this.defaultSolanaChain) {
       SolStoreUtil.setCurrentChain(this.defaultSolanaChain)
       SolStoreUtil.setCaipChainId(`solana:${this.defaultSolanaChain.chainId}`)
     }
 
-    if (defaultChain) {
-      this.appKit?.setCaipNetwork(defaultChain)
+    if (this.defaultChain) {
+      this.appKit?.setCaipNetwork(this.defaultChain)
     }
 
     this.syncNetwork()

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -258,6 +258,10 @@ export const NetworkController = {
 
     const requestedCaipNetworks = this.getRequestedCaipNetworks()
 
+    if (!requestedCaipNetworks.length) {
+      return true
+    }
+
     return requestedCaipNetworks?.some(network => network.id === activeCaipNetwork?.id)
   },
 

--- a/packages/scaffold-ui/src/modal/w3m-account-button/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-account-button/index.ts
@@ -1,5 +1,6 @@
 import {
   AccountController,
+  AssetController,
   AssetUtil,
   CoreHelperUtil,
   ModalController,
@@ -38,6 +39,8 @@ export class W3mAccountButton extends LitElement {
 
   @state() private network = NetworkController.state.caipNetwork
 
+  @state() private networkImage = this.network ? AssetUtil.getNetworkImage(this.network) : undefined
+
   @state() private isUnsupportedChain = NetworkController.state.isUnsupportedChain
 
   // -- Lifecycle ----------------------------------------- //
@@ -45,6 +48,11 @@ export class W3mAccountButton extends LitElement {
     super()
     this.unsubscribe.push(
       ...[
+        AssetController.subscribeNetworkImages(() => {
+          this.networkImage = this.network?.imageId
+            ? AssetUtil.getNetworkImage(this.network)
+            : undefined
+        }),
         AccountController.subscribe(val => {
           if (val.isConnected) {
             this.address = val.address
@@ -62,6 +70,7 @@ export class W3mAccountButton extends LitElement {
         }),
         NetworkController.subscribeKey('caipNetwork', val => {
           this.network = val
+          this.networkImage = val?.imageId ? AssetUtil.getNetworkImage(val) : undefined
         }),
         NetworkController.subscribeKey('isUnsupportedChain', val => {
           this.isUnsupportedChain = val
@@ -76,7 +85,6 @@ export class W3mAccountButton extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    const networkImage = AssetUtil.getNetworkImage(this.network)
     const showBalance = this.balance === 'show'
 
     return html`
@@ -85,7 +93,7 @@ export class W3mAccountButton extends LitElement {
         .isUnsupportedChain=${this.isUnsupportedChain}
         address=${ifDefined(this.address)}
         profileName=${ifDefined(this.profileName)}
-        networkSrc=${ifDefined(networkImage)}
+        networkSrc=${ifDefined(this.networkImage)}
         avatarSrc=${ifDefined(this.profileImage)}
         balance=${showBalance
           ? CoreHelperUtil.formatBalance(this.balanceVal, this.balanceSymbol)

--- a/packages/scaffold-ui/src/modal/w3m-network-button/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-network-button/index.ts
@@ -1,5 +1,7 @@
 import {
   AccountController,
+  ApiController,
+  AssetController,
   AssetUtil,
   EventsController,
   ModalController,
@@ -26,6 +28,8 @@ export class W3mNetworkButton extends LitElement {
 
   @state() private network = NetworkController.state.caipNetwork
 
+  @state() private networkImage = this.network ? AssetUtil.getNetworkImage(this.network) : undefined
+
   @state() private connected = AccountController.state.isConnected
 
   @state() private loading = ModalController.state.loading
@@ -36,7 +40,15 @@ export class W3mNetworkButton extends LitElement {
   public override firstUpdated() {
     this.unsubscribe.push(
       ...[
-        NetworkController.subscribeKey('caipNetwork', val => (this.network = val)),
+        AssetController.subscribeNetworkImages(() => {
+          this.networkImage = this.network?.imageId
+            ? AssetUtil.getNetworkImage(this.network)
+            : undefined
+        }),
+        NetworkController.subscribeKey('caipNetwork', val => {
+          this.network = val
+          this.networkImage = val?.imageId ? AssetUtil.getNetworkImage(val) : undefined
+        }),
         AccountController.subscribeKey('isConnected', val => (this.connected = val)),
         ModalController.subscribeKey('loading', val => (this.loading = val)),
         NetworkController.subscribeKey('isUnsupportedChain', val => (this.isUnsupportedChain = val))
@@ -55,7 +67,7 @@ export class W3mNetworkButton extends LitElement {
         data-testid="wui-network-button"
         .disabled=${Boolean(this.disabled || this.loading)}
         .isUnsupportedChain=${this.isUnsupportedChain}
-        imageSrc=${ifDefined(AssetUtil.getNetworkImage(this.network))}
+        imageSrc=${ifDefined(this.networkImage)}
         @click=${this.onClick.bind(this)}
       >
         ${this.getLabel()}

--- a/packages/scaffold-ui/src/modal/w3m-network-button/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-network-button/index.ts
@@ -1,6 +1,5 @@
 import {
   AccountController,
-  ApiController,
   AssetController,
   AssetUtil,
   EventsController,

--- a/packages/scaffold-utils/src/ethers/EthersHelpersUtil.ts
+++ b/packages/scaffold-utils/src/ethers/EthersHelpersUtil.ts
@@ -1,3 +1,4 @@
+import { ConstantsUtil as CommonConstantsUtil } from '@web3modal/common'
 import type { CaipNetwork } from '@web3modal/core'
 import { ConstantsUtil } from '../ConstantsUtil.js'
 import { PresetsUtil } from '../PresetsUtil.js'
@@ -12,7 +13,8 @@ export const EthersHelpersUtil = {
     return {
       id: `${ConstantsUtil.EIP155}:${chain.chainId}`,
       name: chain.name,
-      imageId: PresetsUtil.EIP155NetworkImageIds[chain.chainId]
+      imageId: PresetsUtil.EIP155NetworkImageIds[chain.chainId],
+      chain: CommonConstantsUtil.CHAIN.EVM
     } as CaipNetwork
   },
   hexStringToNumber(value: string) {

--- a/packages/scaffold-utils/src/solana/SolanaHelpersUtils.ts
+++ b/packages/scaffold-utils/src/solana/SolanaHelpersUtils.ts
@@ -34,6 +34,7 @@ export const SolHelpersUtil = {
       return {
         ...selectedChain,
         id: `solana:${chainId}`,
+        chainId,
         imageId: PresetsUtil.EIP155NetworkImageIds[chainId],
         chain: CommonConstantsUtil.CHAIN.SOLANA
       } as const
@@ -42,6 +43,7 @@ export const SolHelpersUtil = {
     return {
       ...SolConstantsUtil.DEFAULT_CHAIN,
       id: `solana:${chainId}`,
+      chainId,
       imageId: PresetsUtil.EIP155NetworkImageIds[chainId],
       chain: CommonConstantsUtil.CHAIN.SOLANA
     } as const


### PR DESCRIPTION
# Description

In the ethers/ethers5/solana adapters, we are not setting the default caip network when users pass chain object to `defaultChain` parameter for the `createWeb3Modal`. 

Besides, fixes a few other things:
- Due to multi-chain architecture, `checkIfSupportedNetwork` is running false since the requested caip networks are false at first (before adapters initialized). This causing users to see `Unsupported Network` page when they open the AppKit for the first time.
- We are rendering the network image before the network image is being fetched. Thus, the network image is getting empty. Added event listeners of `AssetsController` and update the network image when they are stored. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
