### PR TITLE
chore: add NEXT_PUBLIC_SECURE_SITE_SDK_URL to CSP

### DIFF
--- a/apps/laboratory/next.config.mjs
+++ b/apps/laboratory/next.config.mjs
@@ -12,7 +12,9 @@ const cspHeader = `
   img-src * 'self' data: blob: https://walletconnect.org https://walletconnect.com https://secure.walletconnect.com https://secure.walletconnect.org https://tokens-data.1inch.io https://tokens.1inch.io https://ipfs.io https://lab.web3modal.com;
   font-src 'self' https://fonts.gstatic.com;
   connect-src 'self' https://react-wallet.walletconnect.com https://rpc.walletconnect.com https://rpc.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org wss://www.walletlink.org https://o1095249.ingest.sentry.io;
-  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;
+  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org ${
+    process.env.NEXT_PUBLIC_SECURE_SITE_SDK_URL
+  };
   object-src 'none';
   base-uri 'self';
   form-action 'self';

--- a/apps/laboratory/next.config.mjs
+++ b/apps/laboratory/next.config.mjs
@@ -13,7 +13,7 @@ const cspHeader = `
   font-src 'self' https://fonts.gstatic.com;
   connect-src 'self' https://react-wallet.walletconnect.com https://rpc.walletconnect.com https://rpc.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org wss://www.walletlink.org https://o1095249.ingest.sentry.io;
   frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org ${
-    process.env.NEXT_PUBLIC_SECURE_SITE_SDK_URL
+    process.env.NEXT_PUBLIC_SECURE_SITE_SDK_URL || ''
   };
   object-src 'none';
   base-uri 'self';


### PR DESCRIPTION


# Description

- Adds `NEXT_PUBLIC_SECURE_SITE_SDK_URL` to  CSP `frame-src` field to allow for secure-site previews to be injected into lab when being called from e2e workflows

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
