### PR TITLE
chore: use apiVersion v2 on names endpoint

### DIFF
--- a/packages/core/src/controllers/BlockchainApiController.ts
+++ b/packages/core/src/controllers/BlockchainApiController.ts
@@ -313,7 +313,8 @@ export const BlockchainApiController = {
     return state.api.get<BlockchainApiLookupEnsName>({
       path: `/v1/profile/account/${name}${CommonConstantsUtil.WC_NAME_SUFFIX}`,
       params: {
-        projectId: OptionsController.state.projectId
+        projectId: OptionsController.state.projectId,
+        apiVersion: '2'
       }
     })
   },
@@ -323,7 +324,8 @@ export const BlockchainApiController = {
       path: `/v1/profile/reverse/${address}`,
       params: {
         sender: AccountController.state.address,
-        projectId: OptionsController.state.projectId
+        projectId: OptionsController.state.projectId,
+        apiVersion: '2'
       }
     })
   },


### PR DESCRIPTION
# Description
- forwards `apiVersion: 2` query parameter to blockchain API making it respond `[]` instead of `HTTP 404` for addresses without names or unregistered names.

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1012

# Checklist

- [] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
