### PR TITLE
chore: fix public URL

### DIFF
--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -9,6 +9,11 @@ export const WC_COSIGNER_BASE_URL = 'https://rpc.walletconnect.org/v1/sessions'
 export const USEROP_BUILDER_SERVICE_BASE_URL = 'https://react-wallet.walletconnect.com/api'
 
 export function getPublicUrl() {
+  const publicUrl = process.env['NEXT_PUBLIC_PUBLIC_URL']
+  if (publicUrl) {
+    return publicUrl
+  }
+
   const vercelUrl = process.env['NEXT_PUBLIC_VERCEL_URL']
   if (vercelUrl) {
     return `https://${vercelUrl}`


### PR DESCRIPTION
# Description

For some reason custom `NEXT_PUBLIC_VERCEL_URL` environment variables were being ignored. This uses a different variable that isn't automatically set by Vercel.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)