### PR TITLE
fix: import valtio from vanilla path

### DIFF
--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -14,7 +14,7 @@ import type { W3mFrameTypes } from '@web3modal/wallet'
 import { ChainController } from './ChainController.js'
 import type { Chain } from '@web3modal/common'
 import { NetworkController } from './NetworkController.js'
-import { proxy, ref } from 'valtio'
+import { proxy, ref } from 'valtio/vanilla'
 
 // -- Types --------------------------------------------- //
 export interface AccountControllerState {

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -1,4 +1,4 @@
-import { proxyMap, subscribeKey as subKey } from 'valtio/utils'
+import { proxyMap, subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { proxy, ref, subscribe as sub } from 'valtio/vanilla'
 import type { CaipNetwork, ChainAdapter, Connector } from '../utils/TypeUtil.js'
 

--- a/packages/core/src/controllers/EnsController.ts
+++ b/packages/core/src/controllers/EnsController.ts
@@ -1,4 +1,4 @@
-import { subscribeKey as subKey } from 'valtio/utils'
+import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { proxy, subscribe as sub } from 'valtio/vanilla'
 import { BlockchainApiController } from './BlockchainApiController.js'
 import type { BlockchainApiEnsError } from '../utils/TypeUtil.js'

--- a/packages/core/src/controllers/SwapController.ts
+++ b/packages/core/src/controllers/SwapController.ts
@@ -1,4 +1,4 @@
-import { subscribeKey as subKey } from 'valtio/utils'
+import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { proxy, subscribe as sub } from 'valtio/vanilla'
 import { AccountController } from './AccountController.js'
 import { ConstantsUtil } from '../utils/ConstantsUtil.js'


### PR DESCRIPTION
Currently most of imports are from valtio vanilla, but these are the only ones that are left out that are problematic to projects that don't need to have react in their dependencies.
This PR aims to fix that.

# Description

adds `/vanilla` to import paths where applicable

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
