### PR TITLE
fix: fallback to account chains to get session chains

### DIFF
--- a/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
+++ b/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
@@ -217,7 +217,20 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
   }
 
   private get sessionChains() {
-    return this.session?.namespaces['solana']?.chains || []
+    const solanaNamespace = this.session?.namespaces['solana']
+
+    if (!solanaNamespace) {
+      return []
+    }
+
+    const chains = solanaNamespace.chains || []
+    const accountsChains = solanaNamespace.accounts.map(account => {
+      const [chainNamespace, chainId] = account.split(':')
+
+      return `${chainNamespace}:${chainId}`
+    })
+
+    return Array.from(new Set([...chains, ...accountsChains]))
   }
 
   private serializeTransaction(transaction: AnyTransaction) {

--- a/packages/base/adapters/solana/web3js/tests/WalletConnectProvider.test.ts
+++ b/packages/base/adapters/solana/web3js/tests/WalletConnectProvider.test.ts
@@ -289,4 +289,31 @@ describe('WalletConnectProvider specific tests', () => {
       'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
     )
   })
+
+  it('should get chains from namespace accounts', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: [
+                'solana_signTransaction',
+                'solana_signMessage',
+                'solana_signAndSendTransaction'
+              ],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    expect(walletConnectProvider.chains).toEqual([TestConstants.chains[0]])
+  })
 })


### PR DESCRIPTION
# Description

This PR is adding a fallback for `accounts` param when connecting to Solana with `WalletConnectProvider` and the session `chains` param is not available. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
